### PR TITLE
Add builds via Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+dist: xenial
+language: java
+jdk:
+- openjdk8
+cache:
+  directories:
+  - "$HOME/.m2"
+install: true # Override the default install process with a no-op
+script: mvn -B -U verify

--- a/cics-bundle-maven-plugin/pom.xml
+++ b/cics-bundle-maven-plugin/pom.xml
@@ -58,6 +58,12 @@
       <version>4.12</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <version>2.1</version>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildEar.java
+++ b/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildEar.java
@@ -14,8 +14,10 @@ package com.ibm.cics.cbmp;
  * #L%
  */
 
-import static junit.framework.Assert.assertTrue;
+import static org.hamcrest.collection.ArrayMatching.arrayContainingInAnyOrder;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -31,6 +33,7 @@ public class PostBuildEar {
 	private static final String META_INF = "META-INF";
 	private static final String EAR_BASE_NAME = "test-ear-0.0.1-SNAPSHOT";
 	private static final String EAR_BUNDLE_PART = EAR_BASE_NAME + ".earbundle";
+	private static final String EAR_BUNDLE = EAR_BASE_NAME + ".ear";
 
 	static void assertOutput(File root) throws Exception {
 		File bundleArchive = new File(root, "test-bundle/target/test-bundle-0.0.1-SNAPSHOT.cics-bundle");
@@ -43,17 +46,13 @@ public class PostBuildEar {
 		unArchiver.extract();
 		
 		String[] files = tempDir.list();
-		assertEquals(3, files.length);
-		assertEquals(EAR_BUNDLE_PART, files[1]);
-		assertEquals(META_INF, files[2]);
+		assertThat(files, arrayContainingInAnyOrder(META_INF, EAR_BUNDLE_PART, EAR_BUNDLE));
 		
 		List<String> wbpLines = FileUtils.readLines(new File(tempDir, EAR_BUNDLE_PART));
 		assertEquals(2, wbpLines.size());
 		assertTrue(wbpLines.get(0).startsWith("<?xml"));
 		assertTrue(wbpLines.get(0).endsWith("?>"));
 		assertEquals("<earbundle jvmserver=\"EYUCMCIJ\" symbolicname=\"test-ear\"/>", wbpLines.get(1));
-		
-		assertEquals(EAR_BASE_NAME + ".ear", files[0]);
 		
 		File metaInf = new File(tempDir, META_INF);
 		files = metaInf.list();

--- a/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildOsgi.java
+++ b/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildOsgi.java
@@ -14,8 +14,10 @@ package com.ibm.cics.cbmp;
  * #L%
  */
 
-import static junit.framework.Assert.assertTrue;
+import static org.hamcrest.collection.ArrayMatching.arrayContainingInAnyOrder;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -31,6 +33,7 @@ public class PostBuildOsgi {
 	private static final String META_INF = "META-INF";
 	private static final String BASE_NAME = "test-osgi-0.0.1-SNAPSHOT";
 	private static final String OSGI_BUNDLE_PART = BASE_NAME + ".osgibundle";
+	private static final String OSGI_BUNDLE = BASE_NAME + ".jar";
 
 	static void assertOutput(File root) throws Exception {
 		File bundleArchive = new File(root, "test-bundle/target/test-bundle-0.0.1-SNAPSHOT.cics-bundle");
@@ -43,10 +46,7 @@ public class PostBuildOsgi {
 		unArchiver.extract();
 		
 		String[] files = tempDir.list();
-		assertEquals(3, files.length);
-		assertEquals(BASE_NAME + ".jar", files[0]);
-		assertEquals(META_INF, files[1]);
-		assertEquals(OSGI_BUNDLE_PART, files[2]);
+		assertThat(files, arrayContainingInAnyOrder(META_INF, OSGI_BUNDLE_PART, OSGI_BUNDLE));
 		
 		List<String> wbpLines = FileUtils.readLines(new File(tempDir, OSGI_BUNDLE_PART));
 		assertEquals(2, wbpLines.size());

--- a/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildWar.java
+++ b/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildWar.java
@@ -14,8 +14,10 @@ package com.ibm.cics.cbmp;
  * #L%
  */
 
-import static junit.framework.Assert.assertTrue;
+import static org.hamcrest.collection.ArrayMatching.arrayContainingInAnyOrder;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -31,6 +33,7 @@ public class PostBuildWar {
 	private static final String META_INF = "META-INF";
 	private static final String BASE_NAME = "test-war-0.0.1-SNAPSHOT";
 	private static final String WAR_BUNDLE_PART = BASE_NAME + ".warbundle";
+	private static final String WAR_BUNDLE = BASE_NAME + ".war";
 
 	static void assertOutput(File root) throws Exception {
 		File bundleArchive = new File(root, "test-bundle/target/test-bundle-0.0.1-SNAPSHOT.cics-bundle");
@@ -43,17 +46,13 @@ public class PostBuildWar {
 		unArchiver.extract();
 		
 		String[] files = tempDir.list();
-		assertEquals(3, files.length);
-		assertEquals(META_INF, files[0]);
-		assertEquals(WAR_BUNDLE_PART, files[1]);
+		assertThat(files, arrayContainingInAnyOrder(META_INF, WAR_BUNDLE_PART, WAR_BUNDLE));
 		
 		List<String> wbpLines = FileUtils.readLines(new File(tempDir, WAR_BUNDLE_PART));
 		assertEquals(2, wbpLines.size());
 		assertTrue(wbpLines.get(0).startsWith("<?xml"));
 		assertTrue(wbpLines.get(0).endsWith("?>"));
 		assertEquals("<warbundle jvmserver=\"EYUCMCIJ\" symbolicname=\"test-war\"/>", wbpLines.get(1));
-		
-		assertEquals(BASE_NAME + ".war", files[2]);
 		
 		File metaInf = new File(tempDir, META_INF);
 		files = metaInf.list();


### PR DESCRIPTION
This adds basic Travis CI support, running a `mvn verify`.

At this point, there are no deployment or publication steps.