### PR TITLE
Add colour to Maven build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ cache:
   directories:
   - "$HOME/.m2"
 install: true # Override the default install process with a no-op
-script: mvn -B -U verify
+script: mvn -Dstyle.color=always -B -U verify


### PR DESCRIPTION
This adds the property to `mvn` to force it to output colourised text, even when running in batch (non-interactive) mode, to make the output more readable.