### PR TITLE
Include version number in bundle part symbolic names

### DIFF
--- a/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/Earbundle.java
+++ b/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/Earbundle.java
@@ -77,7 +77,7 @@ public class Earbundle extends BundlePart {
 		
 		Document document = BuildCICSBundleMojo.DOCUMENT_BUILDER.newDocument();
 		Element rootElement = document.createElement("earbundle");
-		rootElement.setAttribute("symbolicname", a.getArtifactId());
+		rootElement.setAttribute("symbolicname", name);
 		rootElement.setAttribute("jvmserver", jvmserver);
 		document.appendChild(rootElement);
 		

--- a/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/Osgibundle.java
+++ b/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/Osgibundle.java
@@ -76,7 +76,7 @@ public class Osgibundle extends BundlePart {
 		
 		Document document = BuildCICSBundleMojo.DOCUMENT_BUILDER.newDocument();
 		Element rootElement = document.createElement("osgibundle");
-		rootElement.setAttribute("symbolicname", a.getArtifactId());
+		rootElement.setAttribute("symbolicname", name);
 		rootElement.setAttribute("jvmserver", jvmserver);
 		document.appendChild(rootElement);
 		

--- a/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/Warbundle.java
+++ b/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/Warbundle.java
@@ -67,7 +67,7 @@ public class Warbundle extends BundlePart {
 		
 		Document document = BuildCICSBundleMojo.DOCUMENT_BUILDER.newDocument();
 		Element rootElement = document.createElement("warbundle");
-		rootElement.setAttribute("symbolicname", a.getArtifactId());
+		rootElement.setAttribute("symbolicname", name);
 		rootElement.setAttribute("jvmserver", jvmserver);
 		document.appendChild(rootElement);
 		

--- a/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildEar.java
+++ b/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildEar.java
@@ -52,7 +52,7 @@ public class PostBuildEar {
 		assertEquals(2, wbpLines.size());
 		assertTrue(wbpLines.get(0).startsWith("<?xml"));
 		assertTrue(wbpLines.get(0).endsWith("?>"));
-		assertEquals("<earbundle jvmserver=\"EYUCMCIJ\" symbolicname=\"test-ear\"/>", wbpLines.get(1));
+		assertEquals("<earbundle jvmserver=\"EYUCMCIJ\" symbolicname=\"test-ear-0.0.1-SNAPSHOT\"/>", wbpLines.get(1));
 		
 		File metaInf = new File(tempDir, META_INF);
 		files = metaInf.list();

--- a/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildOsgi.java
+++ b/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildOsgi.java
@@ -52,7 +52,7 @@ public class PostBuildOsgi {
 		assertEquals(2, wbpLines.size());
 		assertTrue(wbpLines.get(0).startsWith("<?xml"));
 		assertTrue(wbpLines.get(0).endsWith("?>"));
-		assertEquals("<osgibundle jvmserver=\"EYUCMCIJ\" symbolicname=\"test-osgi\"/>", wbpLines.get(1));
+		assertEquals("<osgibundle jvmserver=\"EYUCMCIJ\" symbolicname=\"test-osgi-0.0.1-SNAPSHOT\"/>", wbpLines.get(1));
 		
 		File metaInf = new File(tempDir, META_INF);
 		files = metaInf.list();

--- a/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildWar.java
+++ b/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildWar.java
@@ -52,7 +52,7 @@ public class PostBuildWar {
 		assertEquals(2, wbpLines.size());
 		assertTrue(wbpLines.get(0).startsWith("<?xml"));
 		assertTrue(wbpLines.get(0).endsWith("?>"));
-		assertEquals("<warbundle jvmserver=\"EYUCMCIJ\" symbolicname=\"test-war\"/>", wbpLines.get(1));
+		assertEquals("<warbundle jvmserver=\"EYUCMCIJ\" symbolicname=\"test-war-0.0.1-SNAPSHOT\"/>", wbpLines.get(1));
 		
 		File metaInf = new File(tempDir, META_INF);
 		files = metaInf.list();


### PR DESCRIPTION
Paths to bundle files aren't generated correctly as the Maven dependency's version is included in the file, but not the bundle part symbolic name.  This updates the bundle part's symbolic name to also include the Maven dependency's version