### PR TITLE
Fix OSGi bundlepart creation

### DIFF
--- a/cics-bundle-maven-plugin/src/it/test-reactor-osgi/pom.xml
+++ b/cics-bundle-maven-plugin/src/it/test-reactor-osgi/pom.xml
@@ -22,6 +22,7 @@
   
   <modules>
     <module>test-osgi</module>
+    <module>test-tycho</module>
     <module>test-bundle</module>
   </modules>
   

--- a/cics-bundle-maven-plugin/src/it/test-reactor-osgi/test-bundle/pom.xml
+++ b/cics-bundle-maven-plugin/src/it/test-reactor-osgi/test-bundle/pom.xml
@@ -29,6 +29,12 @@
       <version>${project.version}</version>
       <type>jar</type>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>test-tycho</artifactId>
+      <version>${project.version}</version>
+      <type>jar</type>
+    </dependency>
   </dependencies>
   
   <build>

--- a/cics-bundle-maven-plugin/src/it/test-reactor-osgi/test-osgi/BundleContent/META-INF/MANIFEST.MF
+++ b/cics-bundle-maven-plugin/src/it/test-reactor-osgi/test-osgi/BundleContent/META-INF/MANIFEST.MF
@@ -1,8 +1,0 @@
-Manifest-Version: 1.0
-Bundle-ManifestVersion: 1
-Bundle-Name: OSGi Test Bundle
-Bundle-SymbolicName: test-reactor-osgi
-Bundle-Version: 1.0.0
-Bundle-Vendor: IBM
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
-CICS-MainClass: main.java.test-osgi.TestEndpoint

--- a/cics-bundle-maven-plugin/src/it/test-reactor-osgi/test-tycho/META-INF/MANIFEST.MF
+++ b/cics-bundle-maven-plugin/src/it/test-reactor-osgi/test-tycho/META-INF/MANIFEST.MF
@@ -1,0 +1,4 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: test-tycho
+Bundle-Version: 0.0.1.qualifier

--- a/cics-bundle-maven-plugin/src/it/test-reactor-osgi/test-tycho/build.properties
+++ b/cics-bundle-maven-plugin/src/it/test-reactor-osgi/test-tycho/build.properties
@@ -1,0 +1,15 @@
+###
+# #%L
+# CICS Bundle Maven Plugin
+# %%
+# Copyright (C) 2019 IBM Corp.
+# %%
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+# #L%
+###
+bin.includes = META-INF/,\
+               .,\

--- a/cics-bundle-maven-plugin/src/it/test-reactor-osgi/test-tycho/pom.xml
+++ b/cics-bundle-maven-plugin/src/it/test-reactor-osgi/test-tycho/pom.xml
@@ -19,8 +19,12 @@
     <version>0.0.1-SNAPSHOT</version>
   </parent>
   
-  <artifactId>test-osgi</artifactId>
-  <packaging>jar</packaging>
+  <artifactId>test-tycho</artifactId>
+  <packaging>eclipse-plugin</packaging>
+  
+  <properties>
+    <tycho-version>1.4.0</tycho-version>
+  </properties>
   
   <dependencies>
     <!-- provided -->
@@ -31,37 +35,14 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
-  
+
   <build>
     <plugins>
       <plugin>
-        <groupId>biz.aQute.bnd</groupId>
-        <artifactId>bnd-maven-plugin</artifactId>
-        <version>4.2.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>bnd-process</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-          </archive>
-        </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.5.1</version>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-maven-plugin</artifactId>
+        <version>${tycho-version}</version>
+        <extensions>true</extensions>
       </plugin>
     </plugins>
   </build>

--- a/cics-bundle-maven-plugin/src/it/test-reactor-osgi/test-tycho/src/main/java/test_tycho/TestEndpoint.java
+++ b/cics-bundle-maven-plugin/src/it/test-reactor-osgi/test-tycho/src/main/java/test_tycho/TestEndpoint.java
@@ -1,0 +1,39 @@
+package test_tycho;
+
+/*-
+ * #%L
+ * CICS Bundle Maven Plugin
+ * %%
+ * Copyright (C) 2019 IBM Corp.
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import java.util.Optional;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@ApplicationPath("")
+@Path("")
+public class TestEndpoint extends javax.ws.rs.core.Application {
+	
+	public TestEndpoint() {
+	}
+
+	@GET
+	@Produces(MediaType.APPLICATION_OCTET_STREAM)
+	public Response get() {
+		return Response.ok().build();
+	}
+	
+}

--- a/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/AbstractCICSBundleMojo.java
+++ b/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/AbstractCICSBundleMojo.java
@@ -73,19 +73,19 @@ public abstract class AbstractCICSBundleMojo extends AbstractMojo {
 			default:
 				throw new RuntimeException("Unsupported bundle part type:" + a.getType());
 			case WAR: {
-				Warbundle warbundle = new Warbundle();
+				Warbundle warbundle = new Warbundle(getLog());
 				warbundle.setJvmserver(getDefaultJVMServer());
 				warbundle.setArtifact(new com.ibm.cics.cbmp.Artifact(a));
 				return warbundle;
 			}
 			case EAR: {
-				Earbundle earbundle = new Earbundle();
+				Earbundle earbundle = new Earbundle(getLog());
 				earbundle.setJvmserver(getDefaultJVMServer());
 				earbundle.setArtifact(new com.ibm.cics.cbmp.Artifact(a));
 				return earbundle;
 			}
 			case JAR: {
-				Osgibundle osgibundle = new Osgibundle();
+				Osgibundle osgibundle = new Osgibundle(getLog());
 				osgibundle.setJvmserver(getDefaultJVMServer());
 				osgibundle.setArtifact(new com.ibm.cics.cbmp.Artifact(a));
 				return osgibundle;

--- a/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/Earbundle.java
+++ b/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/Earbundle.java
@@ -1,5 +1,7 @@
 package com.ibm.cics.cbmp;
 
+import org.apache.maven.plugin.logging.Log;
+
 /*-
  * #%L
  * CICS Bundle Maven Plugin
@@ -17,6 +19,10 @@ package com.ibm.cics.cbmp;
 public class Earbundle extends JavaBasedBundlePart {
 	
 	private static final String TYPE = BundleConstants.NS + "/EARBUNDLE";
+	
+	public Earbundle(Log log) {
+		super(log);
+	}
 	
 	@Override
 	protected String getBundlePartFileExtension() {

--- a/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/Osgibundle.java
+++ b/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/Osgibundle.java
@@ -1,5 +1,16 @@
 package com.ibm.cics.cbmp;
 
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.logging.Log;
+import org.w3c.dom.Element;
+
 /*-
  * #%L
  * CICS Bundle Maven Plugin
@@ -18,6 +29,10 @@ public class Osgibundle extends JavaBasedBundlePart  {
 	
 	private static final String TYPE = BundleConstants.NS + "/OSGIBUNDLE";
 	
+	public Osgibundle(Log log) {
+		super(log);
+	}
+
 	@Override
 	protected String getBundlePartFileExtension() {
 		return "osgibundle";
@@ -28,4 +43,103 @@ public class Osgibundle extends JavaBasedBundlePart  {
 		return TYPE;
 	}
 	
+	@Override
+	protected String getSymbolicName(Artifact a) {
+		return a.getArtifactId();
+	}
+
+	protected String getContentPath(Artifact a) {
+		return getOSGiStyleArtifactFilename(a) + "." + a.getType();
+	}
+	
+	@Override
+	protected String getDefinePath(Artifact a) {
+		return getDefinePath(getOSGiStyleArtifactFilename(a));
+	}
+	
+	private String getDefinePath(String filename) {
+		return filename + "." + getBundlePartFileExtension();
+	}
+
+	/**
+	 * Given an artifact, creates an OSGi bundle-style filename like artifact.name_1.2.3 from
+	 * them, taking the version from the artifact's Bundle-Version manifest header.
+	 * @param a
+	 * @return
+	 */
+	private String getOSGiStyleArtifactFilename(Artifact a) {
+		return  a.getArtifactId() + "_" + convertMavenVersionToOSGiVersion(getBundleVersion(a));
+	}
+	
+	@Override
+	protected void addAdditionalNodes(Element rootElement, Artifact a) {
+		rootElement.setAttribute("version", convertMavenVersionToOSGiVersion(getBundleVersion(a)));
+	}
+	
+	/**
+	 * Takes a given Maven version and turns it into an OSGi-compatible version.
+	 * 
+	 * This simple algorithm purely replaces the first hyphen (if found) with a period.
+	 * @param mavenVersion The Maven-style version string
+	 * @return The converted, OSGi-style version
+	 */
+	private String convertMavenVersionToOSGiVersion(String mavenVersion) {
+		return mavenVersion.replaceFirst("-", ".");
+	}
+	
+	/**
+	 * Attempts to retrieve the manifest of the given artifact. Will search inside the artifact, if it's a JAR,
+	 * or will search inside a directory, if (as happens during incremental builds in the IDE), the artifact file
+	 * is still pointing into the classes directory.
+	 * @param a The Artifact to retrieve
+	 * @return The manifest, or null if none was found
+	 */
+	private Manifest getManifest(Artifact a) {
+		File artifactFile = a.getFile();
+		try {
+			if (artifactFile.exists()) {
+				if (artifactFile.isFile()) {
+					try (JarFile jarFile = new JarFile(a.getFile())) {
+						return jarFile.getManifest();
+					}
+				} else {
+					File manifestFile = new File(artifactFile, "META-INF/MANIFEST.MF");
+					if (manifestFile.exists()) {
+						return new Manifest(new BufferedInputStream(new FileInputStream(manifestFile)));
+					}
+				}
+			}
+		} catch (IOException e) {
+			throw new MojoExecutionRuntimeException("Error reading OSGi bundle manifest", e);
+		}
+		return null;
+	}
+	
+	/**
+	 * Gets a specific header from the given manifest.
+	 * @param manifest The manifest to search in
+	 * @param headerName The name of the header to find
+	 * @return The header, or null if the header is not present.
+	 */
+	private static String getManifestHeader(Manifest manifest, String headerName) {
+		return manifest.getMainAttributes().getValue(headerName);
+	}
+
+	/**
+	 * Gets the Bundle-Version header inside the given artifact's manifest.
+	 * @param a The Artifact to find the Bundle-Version of 
+	 * @return The version or null if the manifest, or the header in the manifest, is not present
+	 */
+	private String getBundleVersion(Artifact a) {
+		Manifest manifest = getManifest(a);
+		if (manifest != null) {
+			String bundleVersion = getManifestHeader(manifest, "Bundle-Version");
+			if (bundleVersion != null) {
+				return bundleVersion;
+			}
+		}
+		
+		return a.getVersion();
+	}
+
 }

--- a/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/Warbundle.java
+++ b/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/Warbundle.java
@@ -1,5 +1,7 @@
 package com.ibm.cics.cbmp;
 
+import org.apache.maven.plugin.logging.Log;
+
 /*-
  * #%L
  * CICS Bundle Maven Plugin
@@ -17,6 +19,10 @@ package com.ibm.cics.cbmp;
 public class Warbundle extends JavaBasedBundlePart  {
 	
 	private static final String TYPE = BundleConstants.NS + "/WARBUNDLE";
+	
+	public Warbundle(Log log) {
+		super(log);
+	}
 	
 	@Override
 	protected String getBundlePartFileExtension() {

--- a/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildOsgi.java
+++ b/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildOsgi.java
@@ -14,13 +14,17 @@ package com.ibm.cics.cbmp;
  * #L%
  */
 
-import static org.hamcrest.collection.ArrayMatching.arrayContainingInAnyOrder;
+import static org.hamcrest.collection.ArrayMatching.hasItemInArray;
+import static org.hamcrest.collection.IsIn.in;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.text.MatchesPattern.matchesPattern;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.nio.file.Files;
+import java.util.Arrays;
 import java.util.List;
 
 import org.apache.commons.io.FileUtils;
@@ -31,9 +35,15 @@ public class PostBuildOsgi {
 
 	private static final String CICS_XML = "cics.xml";
 	private static final String META_INF = "META-INF";
-	private static final String BASE_NAME = "test-osgi-0.0.1-SNAPSHOT";
-	private static final String OSGI_BUNDLE_PART = BASE_NAME + ".osgibundle";
-	private static final String OSGI_BUNDLE = BASE_NAME + ".jar";
+	private static final String BND_SYMBOLIC_NAME = "test-osgi";
+	private static final String TYCHO_SYMBOLIC_NAME = "test-tycho";
+	private static final String VERSION_REGEX = "0\\.0\\.1\\.[0-9]{12}";
+	private static final String BUNDLE_PART_EXT_REGEX = "\\.osgibundle";
+	private static final String BUNDLE_EXT_REGEX = "\\.jar";
+	private static final String BND_BUNDLE_PART_REGEX = BND_SYMBOLIC_NAME + "_" + VERSION_REGEX + BUNDLE_PART_EXT_REGEX;
+	private static final String TYCHO_BUNDLE_PART_REGEX = TYCHO_SYMBOLIC_NAME + "_" + VERSION_REGEX + BUNDLE_PART_EXT_REGEX;
+	private static final String BND_BUNDLE_REGEX = BND_SYMBOLIC_NAME + "_" + VERSION_REGEX + BUNDLE_EXT_REGEX;
+	private static final String TYCHO_BUNDLE_REGEX = TYCHO_SYMBOLIC_NAME + "_" + VERSION_REGEX + BUNDLE_EXT_REGEX;
 
 	static void assertOutput(File root) throws Exception {
 		File bundleArchive = new File(root, "test-bundle/target/test-bundle-0.0.1-SNAPSHOT.cics-bundle");
@@ -46,13 +56,30 @@ public class PostBuildOsgi {
 		unArchiver.extract();
 		
 		String[] files = tempDir.list();
-		assertThat(files, arrayContainingInAnyOrder(META_INF, OSGI_BUNDLE_PART, OSGI_BUNDLE));
+		assertThat(META_INF, is(in(files)));
+		assertThat(files, hasItemInArray(matchesPattern(BND_BUNDLE_PART_REGEX)));
+		assertThat(files, hasItemInArray(matchesPattern(BND_BUNDLE_REGEX)));
+		assertThat(files, hasItemInArray(matchesPattern(TYCHO_BUNDLE_PART_REGEX)));
+		assertThat(files, hasItemInArray(matchesPattern(TYCHO_BUNDLE_REGEX)));
+		assertEquals(5, files.length);
 		
-		List<String> wbpLines = FileUtils.readLines(new File(tempDir, OSGI_BUNDLE_PART));
-		assertEquals(2, wbpLines.size());
-		assertTrue(wbpLines.get(0).startsWith("<?xml"));
-		assertTrue(wbpLines.get(0).endsWith("?>"));
-		assertEquals("<osgibundle jvmserver=\"EYUCMCIJ\" symbolicname=\"test-osgi-0.0.1-SNAPSHOT\"/>", wbpLines.get(1));
+		{
+			String bundlePartFile = Arrays.stream(files).filter(f -> f.matches(BND_BUNDLE_PART_REGEX)).findFirst().get();
+			List<String> wbpLines = FileUtils.readLines(new File(tempDir, bundlePartFile));
+			assertEquals(2, wbpLines.size());
+			assertTrue(wbpLines.get(0).startsWith("<?xml"));
+			assertTrue(wbpLines.get(0).endsWith("?>"));
+			assertThat(wbpLines.get(1), matchesPattern("<osgibundle jvmserver=\"EYUCMCIJ\" symbolicname=\"test-osgi\" version=\"0\\.0\\.1\\.[0-9]{12}\"/>"));
+		}
+		
+		{
+			String bundlePartFile = Arrays.stream(files).filter(f -> f.matches(TYCHO_BUNDLE_PART_REGEX)).findFirst().get();
+			List<String> wbpLines = FileUtils.readLines(new File(tempDir, bundlePartFile));
+			assertEquals(2, wbpLines.size());
+			assertTrue(wbpLines.get(0).startsWith("<?xml"));
+			assertTrue(wbpLines.get(0).endsWith("?>"));
+			assertThat(wbpLines.get(1), matchesPattern("<osgibundle jvmserver=\"EYUCMCIJ\" symbolicname=\"test-tycho\" version=\"0\\.0\\.1\\.[0-9]{12}\"/>"));
+		}
 		
 		File metaInf = new File(tempDir, META_INF);
 		files = metaInf.list();
@@ -61,15 +88,16 @@ public class PostBuildOsgi {
 		
 		List<String> cxLines = FileUtils.readLines(new File(metaInf, CICS_XML));
 		System.out.println(cxLines);
-		assertEquals(7, cxLines.size());
+		assertEquals(8, cxLines.size());
 		assertTrue(cxLines.get(0).startsWith("<?xml"));
 		assertTrue(cxLines.get(0).endsWith("?>"));
 		assertEquals("<manifest xmlns=\"http://www.ibm.com/xmlns/prod/cics/bundle\" bundleMajorVer=\"0\" bundleMicroVer=\"1\" bundleMinorVer=\"0\" bundleRelease=\"0\" bundleVersion=\"1\" id=\"test-bundle\">", cxLines.get(1));
 		assertEquals("  <meta_directives>", cxLines.get(2));
 		assertTrue(cxLines.get(3).matches("    <timestamp>\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\d.\\d\\d\\dZ</timestamp>"));
 		assertEquals("  </meta_directives>", cxLines.get(4));
-		assertEquals("  <define name=\"test-osgi-0.0.1-SNAPSHOT\" path=\"test-osgi-0.0.1-SNAPSHOT.osgibundle\" type=\"http://www.ibm.com/xmlns/prod/cics/bundle/OSGIBUNDLE\"/>", cxLines.get(5));
-		assertEquals("</manifest>", cxLines.get(6));
+		assertThat(cxLines.get(5), matchesPattern("  <define name=\"test-osgi-0\\.0\\.1-SNAPSHOT\" path=\"test-osgi_0\\.0\\.1\\.[0-9]{12}\\.osgibundle\" type=\"http://www\\.ibm\\.com/xmlns/prod/cics/bundle/OSGIBUNDLE\"/>"));
+		assertThat(cxLines.get(6), matchesPattern("  <define name=\"test-tycho-0\\.0\\.1-SNAPSHOT\" path=\"test-tycho_0\\.0\\.1\\.[0-9]{12}\\.osgibundle\" type=\"http://www\\.ibm\\.com/xmlns/prod/cics/bundle/OSGIBUNDLE\"/>"));
+		assertEquals("</manifest>", cxLines.get(7));
 	}
 	
 }

--- a/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/TestEarbundle.java
+++ b/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/TestEarbundle.java
@@ -1,5 +1,7 @@
 package com.ibm.cics.cbmp;
 
+import org.apache.maven.plugin.logging.SystemStreamLog;
+
 /*-
  * #%L
  * CICS Bundle Maven Plugin
@@ -18,7 +20,7 @@ public class TestEarbundle extends TestJavaBasedBundlePart {
 
 	@Override
 	protected JavaBasedBundlePart getBundlePart() {
-		return new Warbundle();
+		return new Earbundle(new SystemStreamLog());
 	}
 
 }

--- a/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/TestOsgibundle.java
+++ b/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/TestOsgibundle.java
@@ -1,5 +1,25 @@
 package com.ibm.cics.cbmp;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.jar.Attributes;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.logging.SystemStreamLog;
+import org.junit.Test;
+
 /*-
  * #%L
  * CICS Bundle Maven Plugin
@@ -18,7 +38,78 @@ public class TestOsgibundle extends TestJavaBasedBundlePart {
 
 	@Override
 	protected JavaBasedBundlePart getBundlePart() {
-		return new Osgibundle();
+		return new Osgibundle(new SystemStreamLog());
+	}
+	
+	@Override
+	protected void assertBundlePartContents(String contents) {
+		assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n<"+b.getBundlePartFileExtension()+" jvmserver=\"myjvms\" symbolicname=\"myname\" version=\"1.0.0.somegeneratedqualifier\"/>\n",contents);
+	}
+	
+	@Override
+	protected org.apache.maven.artifact.Artifact mockMavenArtifact(String name, String version, String type) throws IOException {
+		Artifact mavenArtifact = super.mockMavenArtifact(name, version, type);
+		Manifest manifest = new Manifest();
+		manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
+		manifest.getMainAttributes().putValue("Bundle-Version", "1.0.0.somegeneratedqualifier");
+		new JarOutputStream(new FileOutputStream(mavenArtifact.getFile()), manifest).close();
+
+		return mavenArtifact;
+	}
+	
+	protected org.apache.maven.artifact.Artifact mockEarlyMavenArtifact(String name, String version, String type) throws IOException {
+		org.apache.maven.artifact.Artifact mavenArtifact = mock(org.apache.maven.artifact.Artifact.class);
+		when(mavenArtifact.getArtifactId()).thenReturn(name);
+		when(mavenArtifact.getVersion()).thenReturn(version);
+		when(mavenArtifact.getType()).thenReturn(type);
+		
+
+		Path tempSourcePath = Files.createTempDirectory("endp");
+		File tempSourceFile = tempSourcePath.toFile();
+		tempSourceFile.deleteOnExit();
+		new File(tempSourceFile, "META-INF").mkdir();
+		when(mavenArtifact.getFile()).thenReturn(tempSourceFile);
+		
+		
+		Manifest manifest = new Manifest();
+		manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
+		manifest.getMainAttributes().putValue("Bundle-Version", "1.0.0.somegeneratedqualifier");
+		try (OutputStream os = new BufferedOutputStream(new FileOutputStream(new File(tempSourceFile, "META-INF/MANIFEST.MF")))) {
+			manifest.write(os);
+		};
+
+		return mavenArtifact;
+	}
+	
+	@Override
+	protected File getBundlePartFile(File workDir) {
+		return new File(workDir, "myname_1.0.0.somegeneratedqualifier."+b.getBundlePartFileExtension());
+	}
+	
+	protected File expectedContentFile(File workDir) {
+		return new File(workDir, "myname_1.0.0.somegeneratedqualifier.type");
+	}
+	
+
+	
+	/**
+	 * When the bundle part is created, the full dependency JAR may not yet be built. Check that the Bundle-Version
+	 * can be picked up from the MANIFEST.MF put in the target/classes/META-INF folder by plugins like bnd-maven-plugin
+	 */
+	@Test
+	public void writeBundlePartBeforeJarCreated() throws IOException {
+		b.setJvmserver("myjvms");
+		org.apache.maven.artifact.Artifact mavenArtifact = mockEarlyMavenArtifact("myname", "1.0.0-SNAPSHOT", "type");
+		File workDir = createTempDir();
+		
+		b.writeBundlePart(workDir, mavenArtifact, null);
+		
+		File bundlePartFile = getBundlePartFile(workDir);
+		String contents = new String(Files.readAllBytes(bundlePartFile.toPath()));
+
+		assertBundlePartContents(contents);
+
+		FileUtils.deleteDirectory(workDir);
 	}
 
 }

--- a/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/TestWarbundle.java
+++ b/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/TestWarbundle.java
@@ -1,5 +1,7 @@
 package com.ibm.cics.cbmp;
 
+import org.apache.maven.plugin.logging.SystemStreamLog;
+
 /*-
  * #%L
  * CICS Bundle Maven Plugin
@@ -18,7 +20,7 @@ public class TestWarbundle extends TestJavaBasedBundlePart {
 
 	@Override
 	protected JavaBasedBundlePart getBundlePart() {
-		return new Earbundle();
+		return new Warbundle(new SystemStreamLog());
 	}
 
 }


### PR DESCRIPTION
This pull request is related to #15.

This pull request
 - fixes the creation of OSGi bundleparts, by ensuring that the `Bundle-Version` header is correctly from OSGi bundle dependencies' manifests and is set in the OSGi bundlepart's `version` attribute.
 - adds tests for bundles using both the bnd-maven-plugin and Tycho.
 - improves checking of the `BuildContext` so that, in the IDE, fewer builds will be triggered. For example, an IDE build won't be immediately triggered following a Run Config or command-line `mvn` build.