### PR TITLE
 Control the order of <define> elements

### DIFF
--- a/cics-bundle-maven-plugin/src/it/test-reactor-resourcedef/test-bundle/src/main/resources/PROG1.program
+++ b/cics-bundle-maven-plugin/src/it/test-reactor-resourcedef/test-bundle/src/main/resources/PROG1.program
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><cicsdefinitionprogram jvm="NO" name="PROG1" xmlns="http://www.ibm.com/xmlns/prod/CICS/smw2int"/>

--- a/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/bundlegen/BundlepartTypeComparator.java
+++ b/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/bundlegen/BundlepartTypeComparator.java
@@ -1,0 +1,58 @@
+package com.ibm.cics.bundlegen;
+
+/*-
+ * #%L
+ * CICS Bundle Maven Plugin
+ * %%
+ * Copyright (C) 2019 IBM Corp.
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static com.ibm.cics.bundlegen.DefineFactory.uri;
+
+import java.util.Comparator;
+
+import com.ibm.cics.bundlegen.DefineGraph.CycleDetectedException;
+
+public class BundlepartTypeComparator implements Comparator<String> {
+
+	private static final DefineGraph dependencyGraph;
+	
+	static {
+		try {
+			dependencyGraph = new DefineGraph.Builder()
+					.addDependencies(new String[] { uri("EARBUNDLE"), uri("WARBUNDLE"), uri("URIMAP"), uri("EPADAPTER"), uri("TRANSACTION") }, uri("PROGRAM"))
+					.addDependencies(new String[] { uri("EPADAPTER") }, uri("TRANSACTION"))
+					.addDependencies(new String[] { uri("EPADAPTERSET") }, uri("EPADAPTER"))
+					.addDependencies(uri("EVENTBINDING"), new String[] { uri("EPADAPTER"), uri("EPADAPTERSET") })
+					.addDependencies(uri("PROGRAM"), new String[] { uri("OSGIBUNDLE"), uri("LIBRARY") })
+					.addDependencies(uri("URIMAP"), new String[] { uri("PIPELINE"), uri("OSGIBUNDLE"), uri("EARBUNDLE"), uri("WARBUNDLE") })
+					.addDependencies(uri("POLICY"), new String[] { uri("EPADAPTER"), uri("EPADAPTERSET") })
+					.addDependency(uri("PROGRAM"), uri("FILE"))
+					.build();
+		} catch (CycleDetectedException e) {
+			throw new RuntimeException("Cycles detected in define graph", e);
+		}
+	}
+	
+	@Override
+	public int compare(String o1, String o2) {
+		// -1 when o1 < o2
+		if (dependencyGraph.testDependsOn(o2, o1)) {
+			return -1;
+		}
+		// +1 when o1 > o2
+		if (dependencyGraph.testDependsOn(o1, o2)) {
+			return 1;
+		}
+		// Otherwise 0
+		return 0;
+	}
+
+}

--- a/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/bundlegen/DefineFactory.java
+++ b/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/bundlegen/DefineFactory.java
@@ -27,20 +27,20 @@ public class DefineFactory {
 	}
 	
 	private static Map<String, String> fileExtensionToType = Stream.of(new String[][] {
-		  { "pipeline", "PIPELINE" }, 
-		  { "packageset", "PACKAGESET" }, 
-		  { "epadapter", "EPADAPTER" }, 
-		  { "epadapterset", "EPADAPTERSET" }, 
-		  { "file", "FILE" }, 
-		  { "library", "LIBRARY" }, 
-		  { "policy", "POLICY" }, 
-		  { "program", "PROGRAM" }, 
-		  { "tcpipservice", "TCPIPSERVICE" }, 
-		  { "transaction", "TRANSACTION" }, 
-		  { "urimap", "URIMAP" }, 
-		  { "evbind", "EVENTBINDING" }, 
+		  { "pipeline", uri("PIPELINE") }, 
+		  { "packageset", uri("PACKAGESET") }, 
+		  { "epadapter", uri("EPADAPTER") }, 
+		  { "epadapterset", uri("EPADAPTERSET") }, 
+		  { "file", uri("FILE") }, 
+		  { "library", uri("LIBRARY") }, 
+		  { "policy", uri("POLICY") }, 
+		  { "program", uri("PROGRAM") }, 
+		  { "tcpipservice", uri("TCPIPSERVICE") }, 
+		  { "transaction", uri("TRANSACTION") }, 
+		  { "urimap", uri("URIMAP") }, 
+		  { "evbind", uri("EVENTBINDING") }, 
 		}).collect(Collectors.toMap(data -> data[0], data -> data[1]));
-
+	
 	public static Optional<Define> createDefine(File file, Log log) {
 		Optional<String> type = getBundlePartTypeUri(file, log);
 		String fileName = file.getName();
@@ -59,18 +59,22 @@ public class DefineFactory {
 		String fileName = f.getName();
 		int dot = fileName.lastIndexOf(".");
 		if (dot > 0) {
-			String extension = fileName.substring(dot+1).toLowerCase();
+			String extension = fileName.substring(dot + 1).toLowerCase();
 			boolean contained = fileExtensionToType.containsKey(extension);
 			if(contained) {
-				return Optional.of(BundleConstants.NS+"/"+fileExtensionToType.get(extension));
+				return Optional.of(fileExtensionToType.get(extension));
 			} else {
 				// likely an unsupported type or some other arbitrary file
-				log.log("File "+fileName+" not being treated as a bundle part.");
+				log.log("File " + fileName + " not being treated as a bundle part.");
 				return Optional.empty();
 			}
 		} else {
 			return Optional.empty();
 		}
+	}
+	
+	public static String uri(String typeSuffix) {
+		return BundleConstants.NS + "/" + typeSuffix;
 	}
 	
 }

--- a/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/bundlegen/DefineGraph.java
+++ b/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/bundlegen/DefineGraph.java
@@ -1,0 +1,145 @@
+package com.ibm.cics.bundlegen;
+
+/*-
+ * #%L
+ * CICS Bundle Maven Plugin
+ * %%
+ * Copyright (C) 2019 IBM Corp.
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class DefineGraph {
+
+	public Map<String, Set<String>> typesDependedOnByTypeGraph = new HashMap<>();
+
+	private DefineGraph(Map<String, Set<String>> sourceMap) throws CycleDetectedException {
+		// Clone to avoid subsequent manipulation via the builder
+		sourceMap.forEach((type, typesDependedOnByType) -> {
+			typesDependedOnByTypeGraph.put(type, new HashSet<>(typesDependedOnByType));
+		});
+		checkForCycles();
+	}
+
+	private void checkForCycles() throws CycleDetectedException {
+		Set<String> completedTypes = new HashSet<>(typesDependedOnByTypeGraph.size());
+		for (String type : typesDependedOnByTypeGraph.keySet()) {
+			List<String> alreadyVisited = new ArrayList<>();
+			visitAndCheckPath(type, alreadyVisited, completedTypes);
+			completedTypes.add(type);
+		}
+	}
+
+	private void visitAndCheckPath(String type, List<String> alreadyVisited, Set<String> completedTypes)
+			throws CycleDetectedException {
+		boolean newVisit = !alreadyVisited.contains(type);
+		if (!newVisit) {
+			throw new CycleDetectedException("Cycle detected in define graph:\n\n" + alreadyVisited.stream().collect(Collectors.joining(" depends on\n")) + " depends on\n" + type);
+		}
+		alreadyVisited.add(type);
+		Set<String> typesDependedOnByType = typesDependedOnByTypeGraph.get(type);
+		if (typesDependedOnByType != null) {
+			for (String typeDependedOn : typesDependedOnByType) {
+				if (!completedTypes.contains(typeDependedOn)) {
+					visitAndCheckPath(typeDependedOn, new ArrayList<>(alreadyVisited), completedTypes);
+				}
+			}
+		}
+
+	}
+
+	public boolean testDependsOn(String type, String dependsOnType) {
+		Set<String> typesDependedOnByType = typesDependedOnByTypeGraph.get(type);
+		if (typesDependedOnByType != null) {
+			for (String typeDependedOnByType : typesDependedOnByType) {
+				if (dependsOnType.equals(typeDependedOnByType)) {
+					return true;
+				}
+				boolean indirectResult = testDependsOn(typeDependedOnByType, dependsOnType);
+				if (indirectResult) {
+					return true;
+				}
+			}
+		}
+		return false;
+
+	}
+
+	public static class Builder {
+
+		private Map<String, Set<String>> typesDependedOnByTypeGraph = new HashMap<>();
+
+		public Builder addDependencies(String type, String[] dependsOnTypes) {
+			Arrays.asList(dependsOnTypes).forEach(t -> addDependency(type, t));
+			return this;
+		}
+
+		public Builder addDependencies(String[] types, String dependOnType) {
+			Arrays.asList(types).forEach(t -> addDependency(t, dependOnType));
+			return this;
+		}
+
+		public Builder addDependency(String type, String dependsOnType) {
+			Set<String> typesDependedOnByThisType = typesDependedOnByTypeGraph.get(type);
+			if (typesDependedOnByThisType == null) {
+				typesDependedOnByTypeGraph.put(type, typesDependedOnByThisType = new HashSet<>());
+			}
+			typesDependedOnByThisType.add(dependsOnType);
+			return this;
+		}
+
+		public DefineGraph build() throws CycleDetectedException {
+			return new DefineGraph(typesDependedOnByTypeGraph);
+		}
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((typesDependedOnByTypeGraph == null) ? 0 : typesDependedOnByTypeGraph.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		DefineGraph other = (DefineGraph) obj;
+		if (typesDependedOnByTypeGraph == null) {
+			if (other.typesDependedOnByTypeGraph != null)
+				return false;
+		} else if (!typesDependedOnByTypeGraph.equals(other.typesDependedOnByTypeGraph))
+			return false;
+		return true;
+	}
+
+	public class CycleDetectedException extends Exception {
+
+		private static final long serialVersionUID = 1L;
+
+		private CycleDetectedException(String message) {
+			super(message);
+		}
+
+	}
+
+}

--- a/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/bundlegen/BundlepartTypeComparatorTest.java
+++ b/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/bundlegen/BundlepartTypeComparatorTest.java
@@ -1,0 +1,65 @@
+package com.ibm.cics.bundlegen;
+
+/*-
+ * #%L
+ * CICS Bundle Maven Plugin
+ * %%
+ * Copyright (C) 2019 IBM Corp.
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static com.ibm.cics.bundlegen.DefineFactory.uri;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.Test;
+
+public class BundlepartTypeComparatorTest {
+	
+	BundlepartTypeComparator comparator = new BundlepartTypeComparator();
+	
+	@Test
+	public void uriMapAfterWARBundle() {
+		assertSame(1, comparator.compare(uri("URIMAP"), uri("WARBUNDLE")));
+	}
+	
+	@Test
+	public void osgiBundleBeforeWarBundle() {
+		assertSame(-1, comparator.compare(uri("OSGIBUNDLE"), uri("WARBUNDLE")));
+	}
+	@Test
+	public void warBundleBeforeURImap() {
+		assertSame(-1, comparator.compare(uri("WARBUNDLE"), uri("URIMAP")));
+	}
+	
+	@Test
+	public void sameEqual() {
+		assertSame(0, comparator.compare(uri("OSGIBUNDLE"), uri("OSGIBUNDLE")));
+	}
+	
+	@Test
+	public void peersEqual() {
+		assertSame(0, comparator.compare(uri("EARBUNDLE"), uri("WARBUNDLE")));
+	}
+	
+	@Test
+	public void sortOSGiBundleAndURIMap() {
+		List<String> defines = Stream.of(uri("URIMAP"), uri("OSGIBUNDLE")).collect(Collectors.toList());
+		List<String> expected = Stream.of(uri("OSGIBUNDLE"), uri("URIMAP")).collect(Collectors.toList());
+		
+		defines.sort(comparator);
+		
+		assertEquals(expected, defines);
+	}
+	
+}

--- a/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/bundlegen/DefineGraphTest.java
+++ b/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/bundlegen/DefineGraphTest.java
@@ -1,0 +1,165 @@
+package com.ibm.cics.bundlegen;
+
+/*-
+ * #%L
+ * CICS Bundle Maven Plugin
+ * %%
+ * Copyright (C) 2019 IBM Corp.
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.Callable;
+
+import org.junit.Test;
+
+import com.ibm.cics.bundlegen.DefineGraph.CycleDetectedException;
+
+public class DefineGraphTest {
+
+	@Test(expected=CycleDetectedException.class)
+	public void selfCycle() throws Exception {
+		new DefineGraph.Builder()
+				.addDependency("A", "A")
+				.build();
+	}
+
+	@Test(expected=CycleDetectedException.class)
+	public void directCycle() throws Exception {
+		new DefineGraph.Builder()
+				.addDependency("A", "B")
+				.addDependency("B", "A")
+				.build();
+	}
+
+	@Test(expected=CycleDetectedException.class)
+	public void indirectCycle() throws Exception {
+		new DefineGraph.Builder()
+				.addDependency("A", "B")
+				.addDependency("C", "C")
+				.addDependency("C", "A")
+				.build();
+	}
+
+	@Test(expected=CycleDetectedException.class)
+	public void branchingIndirectCycle() throws Exception {
+		new DefineGraph.Builder()
+				.addDependency("A", "B")
+				.addDependency("A", "C")
+				.addDependency("C", "A")
+				.build();
+	}
+
+	@Test
+	public void equality() throws Exception {
+		Callable<DefineGraph> graphSupplier = () -> new DefineGraph.Builder()
+				.addDependency("A", "B")
+				.addDependency("C", "D")
+				.addDependency("B", "E")
+				.build();
+		
+		DefineGraph g1 = graphSupplier.call();
+		DefineGraph g2 = graphSupplier.call();
+		
+		assertEquals(g1, g2);
+	}
+
+	@Test
+	public void inequality() throws Exception {
+		DefineGraph g1 = new DefineGraph.Builder()
+				.addDependency("A", "B")
+				.addDependency("C", "D")
+				.addDependency("B", "E")
+				.build();
+		DefineGraph g2 = new DefineGraph.Builder()
+				.addDependency("A", "B")
+				.addDependency("C", "F")
+				.addDependency("B", "E")
+				.build();
+		
+		assertNotEquals(g1, g2);
+	}
+
+	@Test
+	public void multiAddTypes() throws Exception {
+		DefineGraph g1 = new DefineGraph.Builder()
+				.addDependencies(new String[] { "A", "B" }, "C")
+				.addDependency("C", "D")
+				.build();
+		DefineGraph g2 = new DefineGraph.Builder()
+				.addDependency("A", "C")
+				.addDependency("B", "C")
+				.addDependency("C", "D")
+				.build();
+		
+		assertEquals(g1, g2);
+	}
+
+	@Test
+	public void multiAddDependsOnTypes() throws Exception {
+		DefineGraph g1 = new DefineGraph.Builder()
+				.addDependencies("A", new String[] { "B" , "C" })
+				.addDependency("C", "D")
+				.build();
+		DefineGraph g2 = new DefineGraph.Builder()
+				.addDependency("A", "B")
+				.addDependency("A", "C")
+				.addDependency("C", "D")
+				.build();
+		
+		assertEquals(g1, g2);
+	}
+
+	@Test
+	public void dependsOnDirect() throws Exception {
+		DefineGraph g = new DefineGraph.Builder()
+				.addDependency("A", "B")
+				.addDependency("C", "D")
+				.addDependency("B", "E")
+				.build();
+		
+		assertTrue(g.testDependsOn("C", "D"));
+	}
+
+	@Test
+	public void dependsOnIndirect() throws Exception {
+		DefineGraph g = new DefineGraph.Builder()
+				.addDependency("A", "B")
+				.addDependency("C", "D")
+				.addDependency("B", "E")
+				.build();
+		
+		assertTrue(g.testDependsOn("A", "E"));
+	}
+
+	@Test
+	public void notDependsOn() throws Exception {
+		DefineGraph g = new DefineGraph.Builder()
+				.addDependency("A", "B")
+				.addDependency("C", "D")
+				.addDependency("B", "E")
+				.build();
+		
+		assertFalse(g.testDependsOn("C", "E"));
+	}
+
+	@Test
+	public void notDependsOnReverseDependency() throws Exception {
+		DefineGraph g = new DefineGraph.Builder()
+				.addDependency("A", "B")
+				.build();
+		
+		assertFalse(g.testDependsOn("B", "A"));
+	}
+
+}

--- a/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildResourcedef.java
+++ b/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildResourcedef.java
@@ -33,6 +33,7 @@ public class PostBuildResourcedef {
 	private static final String META_INF = "META-INF";
 	private static final String EVBIND_BUNDLEPART = "EventBinding.evbind";
 	private static final String URIMAP_BUNDLEPART = "mymap.urimap";
+	private static final String PROGRAM_BUNDLEPART = "PROG1.program";
 	private static final String NOEXTENSION_FILE = "noextension";
 
 	static void assertOutput(File root) throws Exception {
@@ -46,7 +47,7 @@ public class PostBuildResourcedef {
 		unArchiver.extract();
 		
 		String[] files = tempDir.list();
-		assertThat(files, arrayContainingInAnyOrder(META_INF, EVBIND_BUNDLEPART, URIMAP_BUNDLEPART, NOEXTENSION_FILE));
+		assertThat(files, arrayContainingInAnyOrder(META_INF, EVBIND_BUNDLEPART, URIMAP_BUNDLEPART, PROGRAM_BUNDLEPART, NOEXTENSION_FILE));
 		
 		List<String> wbpLines = FileUtils.readLines(new File(tempDir, EVBIND_BUNDLEPART));
 		assertEquals(6, wbpLines.size());
@@ -61,16 +62,17 @@ public class PostBuildResourcedef {
 		
 		List<String> cxLines = FileUtils.readLines(new File(metaInf, CICS_XML));
 		System.out.println(cxLines);
-		assertEquals(8, cxLines.size());
+		assertEquals(9, cxLines.size());
 		assertTrue(cxLines.get(0).startsWith("<?xml"));
 		assertTrue(cxLines.get(0).endsWith("?>"));
 		assertEquals("<manifest xmlns=\"http://www.ibm.com/xmlns/prod/cics/bundle\" bundleMajorVer=\"0\" bundleMicroVer=\"1\" bundleMinorVer=\"0\" bundleRelease=\"0\" bundleVersion=\"1\" id=\"test-bundle\">", cxLines.get(1));
 		assertEquals("  <meta_directives>", cxLines.get(2));
 		assertTrue(cxLines.get(3).matches("    <timestamp>\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\d.\\d\\d\\dZ</timestamp>"));
 		assertEquals("  </meta_directives>", cxLines.get(4));
-		assertEquals("  <define name=\"EventBinding\" path=\"EventBinding.evbind\" type=\"http://www.ibm.com/xmlns/prod/cics/bundle/EVENTBINDING\"/>", cxLines.get(5));
-		assertEquals("  <define name=\"mymap\" path=\"mymap.urimap\" type=\"http://www.ibm.com/xmlns/prod/cics/bundle/URIMAP\"/>", cxLines.get(6));
-		assertEquals("</manifest>", cxLines.get(7));
+		assertEquals("  <define name=\"PROG1\" path=\"PROG1.program\" type=\"http://www.ibm.com/xmlns/prod/cics/bundle/PROGRAM\"/>", cxLines.get(5));
+		assertEquals("  <define name=\"EventBinding\" path=\"EventBinding.evbind\" type=\"http://www.ibm.com/xmlns/prod/cics/bundle/EVENTBINDING\"/>", cxLines.get(6));
+		assertEquals("  <define name=\"mymap\" path=\"mymap.urimap\" type=\"http://www.ibm.com/xmlns/prod/cics/bundle/URIMAP\"/>", cxLines.get(7));
+		assertEquals("</manifest>", cxLines.get(8));
 	}
 
 


### PR DESCRIPTION
This pull request applies a dependency graph to `<define>` elements to avoid users having to order them themselves (or just being ordered in a way that won't work).

The ordering in a cics.xml will be controlled as follows:
- The dependency graph will be used first. Where a bundlepart type depends on another type, the latter will appear before the former.
- Where there's no dependency between resources types, lexicographic ordering of the bundlepart type will be used.
- Within a resource type, lexicographic ordering of the bundlepart name will be used.

This covers just bundlepart types that are currently supported (see README). As we add support for more bundlepart types, we'll need to update the dependency graph.