### PR TITLE
remove pipeline support

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ The `cics-bundle-maven-plugin` currently supports the following CICS bundleparts
  - FILE
  - LIBRARY
  - PACKAGESET
- - PIPELINE
  - POLICY
  - PROGRAM
  - TCPIPSERVICE

--- a/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/bundlegen/DefineFactory.java
+++ b/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/bundlegen/DefineFactory.java
@@ -27,7 +27,6 @@ public class DefineFactory {
 	}
 	
 	private static Map<String, String> fileExtensionToType = Stream.of(new String[][] {
-		  { "pipeline", uri("PIPELINE") }, 
 		  { "packageset", uri("PACKAGESET") }, 
 		  { "epadapter", uri("EPADAPTER") }, 
 		  { "epadapterset", uri("EPADAPTERSET") }, 


### PR DESCRIPTION
pipeline support isn't complete (see #31) - so disabling for now.

Signed-off-by: Dave Nice <dave@niceweb.org.uk>