### PR TITLE
generate epl into binaries

### DIFF
--- a/cics-bundle-maven-plugin/pom.xml
+++ b/cics-bundle-maven-plugin/pom.xml
@@ -125,6 +125,18 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>license-maven-plugin</artifactId>
+          <executions>
+            <execution>
+              <goals>
+                <goal>update-project-license</goal>
+              </goals>
+              <phase>generate-resources</phase>
+            </execution>
+          </executions>
+        </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
call upgrade project license on every build to push a license file into the built Maven plugin.