### PR TITLE
Restore distributionManagement for snapshots

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,19 @@
     <license-plugin-version>1.20</license-plugin-version>
   </properties>
 
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <name>Sonatype Nexus Snapshots</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <repository>
+      <id>ossrh</id>
+      <name>Nexus Release Repository</name>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+  </distributionManagement>
+
   <build>
     <extensions>
       <extension>


### PR DESCRIPTION
The `nexus-staging-maven-plugin` continues to defer to the `<distributionManagement>` section for snapshot builds.

This pull request restores this section as before, so that it can be used for snapshot builds.