### PR TITLE
Update dependency to avoid jackson-databind CVEs

### DIFF
--- a/cics-bundle-maven-plugin/pom.xml
+++ b/cics-bundle-maven-plugin/pom.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.9.1</version>
+      <version>2.9.9.2</version>
     </dependency>
 
     <!-- dependencies to annotations -->


### PR DESCRIPTION
Having been alerted to a vulnerability by Dependabot, this pull request updates to the later security fix.