### PR TITLE
Hide the leftColumn on the maven site

### DIFF
--- a/cics-bundle-maven-plugin/src/site/resources/css/site.css
+++ b/cics-bundle-maven-plugin/src/site/resources/css/site.css
@@ -1,0 +1,15 @@
+/*-
+ * #%L
+ * CICS Bundle Maven Plugin
+ * %%
+ * Copyright (C) 2019 IBM Corp.
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+#leftColumn { display: none;}
+#bodyColumn { margin-left: 1.5em;}

--- a/cics-bundle-maven-plugin/src/site/site.xml
+++ b/cics-bundle-maven-plugin/src/site/site.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  CICS Bundle Maven Plugin
+  %%
+  Copyright (C) 2019 IBM Corp.
+  %%
+  This program and the accompanying materials are made
+  available under the terms of the Eclipse Public License 2.0
+  which is available at https://www.eclipse.org/legal/epl-2.0/
+  
+  SPDX-License-Identifier: EPL-2.0
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/DECORATION/1.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/DECORATION/1.0.0 http://maven.apache.org/xsd/decoration-1.0.0.xsd">
+    
+  <body>
+  </body>
+</project>


### PR DESCRIPTION
Removes all the modules from the menu to empty it (there's no interesting content anyway), and then uses CSS to hide the empty column (slightly hacky).  Another alternative is probably a custom template that doesn't include the left column at all, but that'd be significantly more work!

Signed-off-by: Stewart Francis <stewartfrancis@uk.ibm.com>
