### PR TITLE
Update doc to reference samples, and move the archetype doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,11 +127,11 @@ Snapshot builds are published to the Sonatype OSS Maven snapshots repository.  T
 Use of this plugin will vary depending on what you're starting with and the structure of your project. We have included some samples to demonstrate the different methods. 
 
 [Reactor sample](samples/bundle-reactor-deploy)
-This sample is the best starting place if you don't already have a java project you want you build and want to have a go at building and deploying straight away. This is a reactor project with one module including the source for a web page (including a JCICS call), which will be packaged into a WAR. It has a second module, which creates the bundle and installs this in CICS. 
+This sample is the best starting place if you don't already have a Java project you want you build and want to have a go at building and deploying straight away. This is a reactor project with one module including the source for a web page (including a JCICS call), which will be packaged into a WAR. It has a second module, which creates the bundle and installs this in CICS. 
 Further information [here](samples/bundle-reactor-deploy/README.md)
 
 [WAR sample](samples/bundle-war-deploy)
-This sample shows how you can add to the pom of an existing java Maven project, to build it into a bundle and install it in CICS. 
+This sample shows how you can add to the pom of an existing Java Maven project, to build it into a bundle and install it in CICS. 
 Further information can be found [here](samples/bundle-war-deploy/README.md)
 
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ A collection of Maven plugins and utilities that can be used to build CICS bundl
 
 This project contains:
  - `cics-bundle-maven-plugin`, a Maven plugin that authors CICS bundles for deploying resources into CICS TS. It supports a subset of bundleparts, including Java assets. Read the [Maven doc](https://ibm.github.io/cics-bundle-maven/plugin-info.html) for information about this plugin's goals.
- - `cics-bundle-reactor-archetype`, a Maven archetype that provides a simple reactor build that contains a CICS bundle and a Dynamic Web Project (WAR).
+ - `cics-bundle-reactor-archetype`, a Maven archetype that provides a simple reactor build that contains a CICS bundle and a Dynamic Web Project (WAR). This archetype builds and packages the WAR and CICS bundle.
+ - `cics-bundle-deploy-reactor-archetype`, a Maven archetype that provides a simple reactor build that contains a CICS bundle and a Dynamic Web Project (WAR). This archetype packages the WAR into a CICS Bundle and installs it into CICS.
+ - `samples`, a collection of samples that demonstrate the different ways in which to use the plugin.
 
 ## Supported bundlepart types
 The `cics-bundle-maven-plugin` currently supports the following CICS bundleparts:
@@ -28,68 +30,6 @@ The `cics-bundle-maven-plugin` currently supports the following CICS bundleparts
  * Maven is installed into your environment, or
  * You use a Java IDE that supports Maven, e.g. Eclipse, IntelliJ, VS Code...
 
-## Create a CICS bundle using the template in 5 minutes
-
- Maven archetypes provide templates for how a module could, or should, be structured. By using `cics-bundle-reactor-archetype`, you are provided with a reactor (multi-module build) module, containing a CICS bundle module and a dynamic Web (WAR) module. The CICS bundle is preconfigured to depend on the WAR module. Building the reactor module builds both the children, so you end up with a CICS bundle that contains the built WAR file.
-
-1. Create a Maven module by referring to the [`com.ibm.cics:cics-bundle-reactor-archetype`](https://search.maven.org/artifact/com.ibm.cics/cics-bundle-reactor-archetype/0.0.1/maven-archetype) artifact:
-
-    * ![On command line](images/cmd.png) On command line:
-    
-         ```
-         mvn archetype:generate -DarchetypeGroupId=com.ibm.cics -DarchetypeArtifactId=cics-bundle-reactor-archetype -DarchetypeVersion=0.0.1 -DgroupId=<my-groupid> -DartifactId=<my-artifactId>
-         ```
-
-    * ![In Eclipse](images/eclipse.png) If you're using Eclipse:
-        1. Click **File > New > Maven Project**.
-        1. Click **Next** on the first page
-        1. On the second page, click **Add archetype...** in the New Maven Project dialog and specify the following information:
-    
-            Archetype Group Id: `com.ibm.cics`  
-            Archetype Artifact Id: `cics-bundle-reactor-archetype`              
-            Archetype Version: `0.0.1`  
-
-            Then hit **OK**.  
-        1. From the archetype list, select `cics-bundle-reactor-archetype` and hit **Next**. 
-        1. Specify information about your own project, including the group ID and artifact ID. Then hit **Finish**.  
-
-2. Specify the JVM server that the application will be installed into by default in the `pom.xml` file of the bundle module:
-    
-    ```xml
-    <build>
-      <plugins>
-        <plugin>
-          <groupId>com.ibm.cics</groupId>
-          <artifactId>cics-bundle-maven-plugin</artifactId>
-          <version>0.0.1</version>
-          <extensions>true</extensions>
-          <configuration>
-            <defaultjvmserver>JVMSRV1</defaultjvmserver>
-          </configuration>
-        </plugin>
-      </plugins>
-    </build>
-    ```
-
-    
-3. Build the bundle and install it into your local repository.
-
-    * ![On command line](images/cmd.png) On command line:
-    
-        Switch to the parent module and run:
-        
-        ```
-        mvn install
-        ```
-    
-    * ![In Eclipse](images/eclipse.png) In Eclipse:
-    
-        In the `pom.xml` editor of the parent module, right-click and select **Run As > Maven install**.  
-
-**Result:** Both the CICS bundle and the WAR file on which it depends are built. The generated CICS bundle takes its bundle ID from the Maven module's artifactId and its version from the Maven module's version. Its manifest file is also generated during the build.
-
-
-**What's next:** You can store the built bundle in an artifact repository or deploy it to CICS.
 
 ## Create a CICS bundle using `cics-bundle-maven-plugin`
 
@@ -181,9 +121,86 @@ Snapshot builds are published to the Sonatype OSS Maven snapshots repository.  T
 </project>
 ```
 
-## Building the project
 
-The project is built as a reactor project. By running the parent project's build, all the children will also be built.
+## Samples
+
+Use of this plugin will vary depending on what you're starting with and the structure of your project. We have included some samples to demonstrate the different methods. 
+
+[Reactor sample](samples/bundle-reactor-deploy)
+This sample is the best starting place if you don't already have a java project you want you build and want to have a go at building and deploying straight away. This is a reactor project with one module including the source for a web page (including a JCICS call), which will be packaged into a WAR. It has a second module, which creates the bundle and installs this in CICS. 
+Further information [here](samples/bundle-reactor-deploy/README.md)
+
+[WAR sample](samples/bundle-war-deploy)
+This sample shows how you can add to the pom of an existing java Maven project, to build it into a bundle and install it in CICS. 
+Further information can be found [here](samples/bundle-war-deploy/README.md)
+
+
+## Archetypes
+
+Another way to get started with the plugin is to use one of the provided archetypes. Maven archetypes provide templates for how a module could, or should, be structured. By using `cics-bundle-reactor-archetype`, you are provided with a reactor (multi-module build) module, containing a CICS bundle module and a dynamic Web (WAR) module. The CICS bundle is preconfigured to depend on the WAR module. Building the reactor module builds both the children, so you end up with a CICS bundle that contains the built WAR file. If you use the `cics-bundle-deploy-reactor-archetype` archetype, this is extended to install the CICS bundle in CICS. 
+
+
+1. Create a Maven module by referring to the [`com.ibm.cics:cics-bundle-reactor-archetype`](https://search.maven.org/artifact/com.ibm.cics/cics-bundle-reactor-archetype/0.0.1/maven-archetype) artifact:
+
+    * ![On command line](images/cmd.png) On command line:
+    
+         ```
+         mvn archetype:generate -DarchetypeGroupId=com.ibm.cics -DarchetypeArtifactId=cics-bundle-reactor-archetype -DarchetypeVersion=0.0.1 -DgroupId=<my-groupid> -DartifactId=<my-artifactId>
+         ```
+         
+         Specify the JVM server that the application will be installed into by default in the `pom.xml` file of the bundle module:
+    
+        ```xml
+        <build>
+          <plugins>
+            <plugin>
+              <groupId>com.ibm.cics</groupId>
+              <artifactId>cics-bundle-maven-plugin</artifactId>
+              <version>0.0.1</version>
+              <extensions>true</extensions>
+              <configuration>
+                <defaultjvmserver>JVMSRV1</defaultjvmserver>
+              </configuration>
+            </plugin>
+          </plugins>
+        </build>
+        ```
+
+    * ![In Eclipse](images/eclipse.png) If you're using Eclipse:
+        1. Click **File > New > Maven Project**.
+        1. Click **Next** on the first page
+        1. On the second page, click **Add archetype...** in the New Maven Project dialog and specify the following information:
+    
+            Archetype Group Id: `com.ibm.cics`  
+            Archetype Artifact Id: `cics-bundle-reactor-archetype`              
+            Archetype Version: `0.0.1`  
+
+            Then hit **OK**.  
+        1. From the archetype list, select `cics-bundle-reactor-archetype` and hit **Next**. 
+        1. Specify information about your own project, including the group ID and artifact ID, and the default JVM server. Then hit **Finish**.  
+    
+2. Build the bundle and install it into your local repository.
+
+    * ![On command line](images/cmd.png) On command line:
+    
+        Switch to the parent module and run:
+        
+        ```
+        mvn install
+        ```
+    
+    * ![In Eclipse](images/eclipse.png) In Eclipse:
+    
+        In the `pom.xml` editor of the parent module, right-click and select **Run As > Maven install**.  
+
+**Result:** Both the CICS bundle and the WAR file on which it depends are built. The generated CICS bundle takes its bundle ID from the Maven module's artifactId and its version from the Maven module's version. Its manifest file is also generated during the build.
+
+**What's next:** You can store the built bundle in an artifact repository or deploy it to CICS.
+
+
+## Building this project
+
+This project is built as a reactor project. By running the parent project's build, all the children will also be built.
 
 To build all projects and install them into the local Maven repository, run:
 

--- a/samples/bundle-reactor-deploy/pom.xml
+++ b/samples/bundle-reactor-deploy/pom.xml
@@ -22,6 +22,8 @@
     </pluginRepository>
   </pluginRepositories>
 
+  <!-- The demo-war module will package the source into a war. The demo-bundle module will package this into a CICS bundle and deploy it. 
+       The ordering of the modules doesn't matter as demo-bundle has a dependency on demo-war so it knows to build that first. -->
   <modules>
     <module>demo-war</module>
     <module>demo-bundle</module>

--- a/samples/bundle-war-deploy/README.md
+++ b/samples/bundle-war-deploy/README.md
@@ -1,5 +1,5 @@
-# Bundle war deploy sample
-This sample demonstrates how you can add to an existing pom.xml of a war project that already exists.
+# Bundle WAR deploy sample
+This sample demonstrates how you can add to an existing pom.xml of a WAR project that already exists.
 Everything within the demo-war directory would be an existing Maven project. The additional step to publish this to CICS is the additional plugin in the pom.xml: 
 
 ## Set Up
@@ -8,10 +8,16 @@ Your system programmer should create a bundle definition in CSD and tell you the
 The bundle directory of your bundle definition should be set as follows: `<bundle_deploy_root>/<bundle_id>_<bundle_version>`.  So for this sample, if your bundle_deploy_root was `/u/someuser/bundles/`, the bundle directory would be `/u/someuser/bundles/demo-war_0.0.1`.
 
 ## Using the sample
+There are 2 options of how to use this sample. 
+Option 1 is to use the whole sample as-is, for example, if you want to try this out before using it with an existing Maven project. 
+Option 2 is to extend an existing maven project, which you'd like to package and install as a CICS bundle. 
+
+### Option 1: Using the full sample
 Clone the sample into your preferred IDE
 
-Edit the variables from the below block in demo-war/pom.xml to match the CSD group, CICSplex, region and bundle definition name. 
+Edit the variables from the configuration section below in demo-war/pom.xml to match the CSD group, CICSplex, region and bundle definition name. 
 
+      ```xml
       <plugin>
         <groupId>com.ibm.cics</groupId>
         <artifactId>cics-bundle-maven-plugin</artifactId>
@@ -36,8 +42,39 @@ Edit the variables from the below block in demo-war/pom.xml to match the CSD gro
           </execution>
         </executions>
       </plugin>
+      ```
       
-##Build
+### Option 2: Add to an existing Maven project
+If you already have an existing java Maven project, you can add the below to the plugins section of your pom.xml and edit the configuration variables. Your Maven project should now resemble the sample.
+
+      ```xml
+      <plugin>
+        <groupId>com.ibm.cics</groupId>
+        <artifactId>cics-bundle-maven-plugin</artifactId>
+        <version>0.0.2-SNAPSHOT</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>bundle-war</goal>
+              <goal>deploy</goal>
+            </goals>
+            <configuration>
+              <classifier>cics-bundle</classifier>
+              <jvmserver>JVMSRV1</jvmserver>
+              <url>http://yourcicsurl.com:9080</url>
+              <username>${cics-user-id}</username>
+              <password>${cics-password}</password>
+              <bunddef>DEMOBUNDLE</bunddef>
+              <csdgroup>BAR</csdgroup>
+              <cicsplex>CICSEX56</cicsplex>
+              <region>IYCWEMW2</region>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      ```
+
+## Build
 
 To build the project and install into your local Maven repository, run:
 mvn clean install

--- a/samples/bundle-war-deploy/README.md
+++ b/samples/bundle-war-deploy/README.md
@@ -45,7 +45,7 @@ Edit the variables from the configuration section below in demo-war/pom.xml to m
       ```
       
 ### Option 2: Add to an existing Maven project
-If you already have an existing java Maven project, you can add the below to the plugins section of your pom.xml and edit the configuration variables. Your Maven project should now resemble the sample.
+If you already have an existing Java Maven project, you can add the below to the plugins section of your pom.xml and edit the configuration variables. Your Maven project should now resemble the sample.
 
       ```xml
       <plugin>


### PR DESCRIPTION
Reference the samples in the main readme. I've also moved the section about archetypes down, and updated it so that you only have to edit the defaultjvmserver in the pom if you used command line, otherwise you fill it in in the Eclipse dialog. 

Signed-off-by: Sophie Green <SOPHIEGR@uk.ibm.com>
