### PR TITLE
use wiremock to test samples

### DIFF
--- a/samples/bundle-reactor-deploy/demo-bundle/pom.xml
+++ b/samples/bundle-reactor-deploy/demo-bundle/pom.xml
@@ -49,7 +49,7 @@
             <!-- The below configuration is used to deploy the built bundle to CICS. -->
             <configuration>
               <!-- Set the transport, hostname, and port for your CMCI -->
-              <url>https://yourcicsurl.com:9080</url>
+              <url>http://localhost:9080</url>
               <!-- Use Maven's password encryption, or supply your credentials using environment variables or properties, as shown here. -->
               <username>${cics-user-id}</username>
               <password>${cics-password}</password>

--- a/samples/bundle-war-deploy/demo-war/pom.xml
+++ b/samples/bundle-war-deploy/demo-war/pom.xml
@@ -74,7 +74,7 @@
               <jvmserver>JVMSRV1</jvmserver>
               
               <!-- Set the transport, hostname, and port for your CMCI -->
-              <url>https://yourcicsurl.com:9080</url>
+              <url>http://localhost:9080</url>
               
               <!-- Use Maven's password encryption, or supply your credentials using environment variables or properties, as shown here. -->
               <username>${cics-user-id}</username>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -10,6 +10,7 @@
     <artifactId>cics-bundle-maven</artifactId>
     <version>0.0.2-SNAPSHOT</version>
   </parent>
+  
   <build>
     <plugins>
       <plugin>
@@ -18,7 +19,7 @@
         <configuration>
           <streamLogs>true</streamLogs>
           <showErrors>true</showErrors>
-          <goals>package</goals><!--  stop before we deploy, for now - this requires infrastructure -->
+          <goals>verify</goals>
           <cloneProjectsTo>${project.build.directory}/sample-build</cloneProjectsTo>
           <settingsFile>../cics-bundle-maven-plugin/src/it/settings.xml</settingsFile>
           <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
@@ -34,6 +35,30 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>uk.co.automatictester</groupId>
+        <artifactId>wiremock-maven-plugin</artifactId>          
+        <version>5.0.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>run</goal>
+              <goal>stop</goal>
+            </goals>
+            <configuration>
+              <dir>src/main/resources</dir> <!-- files should copy from here to target/classes which is the default value, but the files aren't being copied -->
+              <params>--port=9080</params>
+            </configuration>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock</artifactId>
+            <version>2.25.0</version>
+          </dependency>
+        </dependencies>
+      </plugin>  
     </plugins>
   </build>
 

--- a/samples/src/main/resources/mappings/acceptAll.json
+++ b/samples/src/main/resources/mappings/acceptAll.json
@@ -1,0 +1,23 @@
+/*-
+ * #%L
+ * samples
+ * %%
+ * Copyright (C) 2019 IBM Corp.
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+{
+	"request": {
+		"method": "POST",
+		"url": "/managedcicsbundles"
+	},
+	"response": {
+		"status": 200,
+		"body": "API response\n"
+	}
+}


### PR DESCRIPTION
Use wiremock to accept deployment request and return 200.

This has limitations - we only detect issues that are validated client-side because we don't actually get as far as the server.