### PR TITLE
JCICS in archetypes

### DIFF
--- a/cics-bundle-deploy-reactor-archetype/src/main/resources/archetype-resources/__rootArtifactId__-war/pom.xml
+++ b/cics-bundle-deploy-reactor-archetype/src/main/resources/archetype-resources/__rootArtifactId__-war/pom.xml
@@ -12,13 +12,33 @@
   <packaging>war</packaging>
   <name>Example web application</name>
 
-  <dependencies>
+  <dependencyManagement>
+    <dependencies>
       <dependency>
-          <groupId>javax.servlet</groupId>
-          <artifactId>javax.servlet-api</artifactId>
-          <version>3.1.0</version>
-          <scope>provided</scope>
+        <groupId>com.ibm.cics</groupId>
+        <artifactId>com.ibm.cics.ts.bom</artifactId>
+        <!--
+          Change to a version that matches your release of CICS TS.
+          See https://repo1.maven.org/maven2/com/ibm/cics/com.ibm.cics.ts.bom/ for available versions.
+        -->
+        <version>LATEST</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.1.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.ibm.cics</groupId>
+      <artifactId>com.ibm.cics.server</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/cics-bundle-deploy-reactor-archetype/src/main/resources/archetype-resources/__rootArtifactId__-war/pom.xml
+++ b/cics-bundle-deploy-reactor-archetype/src/main/resources/archetype-resources/__rootArtifactId__-war/pom.xml
@@ -21,7 +21,7 @@
           Change to a version that matches your release of CICS TS.
           See https://repo1.maven.org/maven2/com/ibm/cics/com.ibm.cics.ts.bom/ for available versions.
         -->
-        <version>LATEST</version>
+        <version>RELEASE</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/cics-bundle-deploy-reactor-archetype/src/main/resources/archetype-resources/__rootArtifactId__-war/src/main/java/com/example/servlet/HelloServlet.java
+++ b/cics-bundle-deploy-reactor-archetype/src/main/resources/archetype-resources/__rootArtifactId__-war/src/main/java/com/example/servlet/HelloServlet.java
@@ -8,6 +8,8 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.ibm.cics.server.Task;
+
 @WebServlet("/hello")
 public class HelloServlet extends HttpServlet {
 
@@ -18,7 +20,7 @@ public class HelloServlet extends HttpServlet {
 			throws ServletException, IOException {
 		response.setContentType("application/json");
 
-		response.getWriter().print("{\"message\": \"Hello World! This message is provided by HelloServlet.\"}");
+		response.getWriter().print("{\"message\": \"Hello World! This message is provided by HelloServlet, running on CICS task " + Task.getTask().getTaskNumber() + ".\"}");
 	}
 
 }

--- a/cics-bundle-maven-plugin/src/it/setup-test-war/pom.xml
+++ b/cics-bundle-maven-plugin/src/it/setup-test-war/pom.xml
@@ -34,6 +34,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
+        <version>3.2.3</version>
         <configuration>
           <failOnMissingWebXml>false</failOnMissingWebXml>
           <packagingExcludes>pom.xml</packagingExcludes>

--- a/cics-bundle-maven-plugin/src/it/test-bundle-deploy-insecure/postbuild.groovy
+++ b/cics-bundle-maven-plugin/src/it/test-bundle-deploy-insecure/postbuild.groovy
@@ -19,7 +19,16 @@ File buildLog = new File(basedir, 'build.log')
 
 assert buildLog.exists()
 // Deployment with <insecure> set
-assert buildLog.text.contains("[INFO] Bundle deployed")
+assert buildLog.text.contains("""\
+(deploy-with-insecure) @ test-bundle-deploy-insecure ---
+[INFO] Deploying bundle to https://localhost:${wiremockPort} into region cicsplex/region
+[INFO] Bundle deployed
+""")
 
 // Deployment without <insecure> set
-assert buildLog.text.contains(":deploy (deploy-and-fail-because-self-signed) on project test-bundle-deploy-insecure: sun.security.validator.ValidatorExceptio")
+assert buildLog.text.contains("""\
+(deploy-and-fail-because-self-signed) @ test-bundle-deploy-insecure ---
+[INFO] Deploying bundle to https://localhost:${wiremockPort} into region cicsplex/region
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD FAILURE
+""")

--- a/cics-bundle-maven-plugin/src/it/test-bundle-ear/pom.xml
+++ b/cics-bundle-maven-plugin/src/it/test-bundle-ear/pom.xml
@@ -34,6 +34,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-ear-plugin</artifactId>
+        <version>3.0.2</version>
         <configuration>
           <failOnMissingWebXml>false</failOnMissingWebXml>
           <packagingExcludes>pom.xml</packagingExcludes>

--- a/cics-bundle-maven-plugin/src/it/test-bundle-eba/pom.xml
+++ b/cics-bundle-maven-plugin/src/it/test-bundle-eba/pom.xml
@@ -33,6 +33,7 @@
       <plugin>
         <groupId>org.apache.aries</groupId>
         <artifactId>eba-maven-plugin</artifactId>
+        <version>1.0.0</version>
         <extensions>true</extensions>
         <configuration>
           <generateManifest>true</generateManifest>

--- a/cics-bundle-maven-plugin/src/it/test-bundle-war-deploy-userprops/pom.xml
+++ b/cics-bundle-maven-plugin/src/it/test-bundle-war-deploy-userprops/pom.xml
@@ -33,6 +33,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
+        <version>3.2.3</version>
         <configuration>
           <failOnMissingWebXml>false</failOnMissingWebXml>
           <packagingExcludes>pom.xml</packagingExcludes>

--- a/cics-bundle-maven-plugin/src/it/test-bundle-war/pom.xml
+++ b/cics-bundle-maven-plugin/src/it/test-bundle-war/pom.xml
@@ -33,6 +33,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
+        <version>3.2.3</version>
         <configuration>
           <failOnMissingWebXml>false</failOnMissingWebXml>
           <packagingExcludes>pom.xml</packagingExcludes>

--- a/cics-bundle-maven-plugin/src/it/test-reactor-eba/test-osgi/pom.xml
+++ b/cics-bundle-maven-plugin/src/it/test-reactor-eba/test-osgi/pom.xml
@@ -49,6 +49,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <version>3.2.0</version>
         <configuration>
           <archive>
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>

--- a/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/BundleValidator.java
+++ b/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/BundleValidator.java
@@ -42,7 +42,7 @@ public class BundleValidator {
 	
 	private static final DifferenceEvaluator TIMESTAMP_EVALUATOR = new DifferenceEvaluator() {
 		
-		private static final String TIMESTAMP_PATTERN = "\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\d.\\d\\d\\dZ";
+		private static final String TIMESTAMP_PATTERN = "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3,6}Z";
 		
 		@Override
 		public ComparisonResult evaluate(Comparison comparison, ComparisonResult outcome) {

--- a/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/BundleValidator.java
+++ b/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/BundleValidator.java
@@ -40,7 +40,7 @@ import org.xmlunit.matchers.CompareMatcher;
 
 public class BundleValidator {
 	
-	private static final DifferenceEvaluator TIMESTAMP_EVALUATOR = new DifferenceEvaluator() {
+	public static final DifferenceEvaluator TIMESTAMP_EVALUATOR = new DifferenceEvaluator() {
 		
 		private static final String TIMESTAMP_PATTERN = "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3,6}Z";
 		
@@ -87,7 +87,7 @@ public class BundleValidator {
 				.forEach(p -> {
 					BundleFileValidator validator = Arrays
 						.stream(validators)
-						.filter(v -> v.getPath().equals(p.toString()))
+						.filter(v -> v.consumesPath(p.toString()))
 						.findFirst()
 						.orElseThrow(() -> new RuntimeException("Unexpected bundle file: " + p));
 					
@@ -106,7 +106,7 @@ public class BundleValidator {
 	
 	public static interface BundleFileValidator {
 		
-		public String getPath();
+		public boolean consumesPath(String p);
 		
 		public void validate(InputStream is) throws RuntimeException;
 	}
@@ -119,12 +119,26 @@ public class BundleValidator {
 			}
 			
 			@Override
-			public String getPath() {
-				return path;
+			public boolean consumesPath(String p) {
+				return path.equals(p.toString());
 			}
 		};
 	}
-
+	
+	public static BundleFileValidator bfmv(String regex, Consumer<InputStream> validator) {
+		return new BundleFileValidator() {
+			@Override
+			public void validate(InputStream is) throws RuntimeException {
+				validator.accept(is);
+			}
+			
+			@Override
+			public boolean consumesPath(String p) {
+				return p.toString().matches(regex);
+			}
+		};
+	}
+	
 	public static BundleFileValidator manifestValidator(String expectedManifest) {
 		return bfv(
 			"/META-INF/cics.xml",

--- a/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildEar.java
+++ b/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildEar.java
@@ -1,5 +1,4 @@
 package com.ibm.cics.cbmp;
-
 /*-
  * #%L
  * CICS Bundle Maven Plugin
@@ -14,62 +13,51 @@ package com.ibm.cics.cbmp;
  * #L%
  */
 
-import static org.hamcrest.collection.ArrayMatching.arrayContainingInAnyOrder;
-import static org.junit.Assert.assertEquals;
+import static com.ibm.cics.cbmp.BundleValidator.assertBundleContents;
+import static com.ibm.cics.cbmp.BundleValidator.bfv;
+import static com.ibm.cics.cbmp.BundleValidator.manifestValidator;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 import java.io.File;
-import java.nio.file.Files;
-import java.util.List;
+import java.nio.file.Path;
 
-import org.apache.commons.io.FileUtils;
-import org.codehaus.plexus.archiver.zip.ZipUnArchiver;
-import org.codehaus.plexus.logging.console.ConsoleLogger;
+import org.xmlunit.matchers.CompareMatcher;
 
 public class PostBuildEar {
 
-	private static final String CICS_XML = "cics.xml";
-	private static final String META_INF = "META-INF";
-	private static final String EAR_BASE_NAME = "test-ear-0.0.1-SNAPSHOT";
+	private static final String EAR_BASE_NAME = "/test-ear-0.0.1-SNAPSHOT";
 	private static final String EAR_BUNDLE_PART = EAR_BASE_NAME + ".earbundle";
 	private static final String EAR_BUNDLE = EAR_BASE_NAME + ".ear";
 
 	static void assertOutput(File root) throws Exception {
-		File bundleArchive = new File(root, "test-bundle/target/test-bundle-0.0.1-SNAPSHOT.zip");
+		Path cicsBundle = root.toPath().resolve("test-bundle/target/test-bundle-0.0.1-SNAPSHOT.zip");
 		
-		File tempDir = Files.createTempDirectory("cbmp").toFile();
-		
-		ZipUnArchiver unArchiver = new ZipUnArchiver(bundleArchive);
-		unArchiver.setDestDirectory(tempDir);
-		unArchiver.enableLogging(new ConsoleLogger());
-		unArchiver.extract();
-		
-		String[] files = tempDir.list();
-		assertThat(files, arrayContainingInAnyOrder(META_INF, EAR_BUNDLE_PART, EAR_BUNDLE));
-		
-		List<String> wbpLines = FileUtils.readLines(new File(tempDir, EAR_BUNDLE_PART));
-		assertEquals(2, wbpLines.size());
-		assertTrue(wbpLines.get(0).startsWith("<?xml"));
-		assertTrue(wbpLines.get(0).endsWith("?>"));
-		assertEquals("<earbundle jvmserver=\"EYUCMCIJ\" symbolicname=\"test-ear-0.0.1-SNAPSHOT\"/>", wbpLines.get(1));
-		
-		File metaInf = new File(tempDir, META_INF);
-		files = metaInf.list();
-		assertEquals(1, files.length);
-		assertEquals(CICS_XML, files[0]);
-		
-		List<String> cxLines = FileUtils.readLines(new File(metaInf, CICS_XML));
-		System.out.println(cxLines);
-		assertEquals(7, cxLines.size());
-		assertTrue(cxLines.get(0).startsWith("<?xml"));
-		assertTrue(cxLines.get(0).endsWith("?>"));
-		assertEquals("<manifest xmlns=\"http://www.ibm.com/xmlns/prod/cics/bundle\" bundleMajorVer=\"0\" bundleMicroVer=\"1\" bundleMinorVer=\"0\" bundleRelease=\"0\" bundleVersion=\"1\" id=\"test-bundle\">", cxLines.get(1));
-		assertEquals("  <meta_directives>", cxLines.get(2));
-		assertTrue(cxLines.get(3).matches("    <timestamp>\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\d.\\d\\d\\dZ</timestamp>"));
-		assertEquals("  </meta_directives>", cxLines.get(4));
-		assertEquals("  <define name=\"test-ear-0.0.1-SNAPSHOT\" path=\"test-ear-0.0.1-SNAPSHOT.earbundle\" type=\"http://www.ibm.com/xmlns/prod/cics/bundle/EARBUNDLE\"/>", cxLines.get(5));
-		assertEquals("</manifest>", cxLines.get(6));
+		assertBundleContents(
+				cicsBundle,
+				manifestValidator(
+					"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" + 
+					"<manifest xmlns=\"http://www.ibm.com/xmlns/prod/cics/bundle\" bundleMajorVer=\"0\" bundleMicroVer=\"1\" bundleMinorVer=\"0\" bundleRelease=\"0\" bundleVersion=\"1\" id=\"test-bundle\">\n" +
+					"  <meta_directives>\n" +
+					"    <timestamp>2019-09-11T21:12:17.023Z</timestamp>\n" +
+					"  </meta_directives>\n" +
+					"  <define name=\"test-ear-0.0.1-SNAPSHOT\" path=\"test-ear-0.0.1-SNAPSHOT.earbundle\" type=\"http://www.ibm.com/xmlns/prod/cics/bundle/EARBUNDLE\"/>\n" +
+					"</manifest>"
+				),
+				bfv(
+					EAR_BUNDLE_PART,
+					is -> assertThat(
+						is,
+						CompareMatcher.isIdenticalTo(
+							"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + 
+							"<earbundle jvmserver=\"EYUCMCIJ\" symbolicname=\"test-ear-0.0.1-SNAPSHOT\"/>"
+						)
+					)
+				),
+				bfv(
+					EAR_BUNDLE,
+					is -> {}
+				)
+			);
 	}
 	
 }

--- a/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildEba.java
+++ b/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildEba.java
@@ -1,5 +1,4 @@
 package com.ibm.cics.cbmp;
-
 /*-
  * #%L
  * CICS Bundle Maven Plugin
@@ -14,62 +13,51 @@ package com.ibm.cics.cbmp;
  * #L%
  */
 
-import static org.hamcrest.collection.ArrayMatching.arrayContainingInAnyOrder;
-import static org.junit.Assert.assertEquals;
+import static com.ibm.cics.cbmp.BundleValidator.assertBundleContents;
+import static com.ibm.cics.cbmp.BundleValidator.bfv;
+import static com.ibm.cics.cbmp.BundleValidator.manifestValidator;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 import java.io.File;
-import java.nio.file.Files;
-import java.util.List;
+import java.nio.file.Path;
 
-import org.apache.commons.io.FileUtils;
-import org.codehaus.plexus.archiver.zip.ZipUnArchiver;
-import org.codehaus.plexus.logging.console.ConsoleLogger;
+import org.xmlunit.matchers.CompareMatcher;
 
 public class PostBuildEba {
 
-	private static final String CICS_XML = "cics.xml";
-	private static final String META_INF = "META-INF";
-	private static final String EBA_BASE_NAME = "test-eba-0.0.1-SNAPSHOT";
+	private static final String EBA_BASE_NAME = "/test-eba-0.0.1-SNAPSHOT";
 	private static final String EBA_BUNDLE_PART = EBA_BASE_NAME + ".ebabundle";
 	private static final String EBA_BUNDLE = EBA_BASE_NAME + ".eba";
 
 	static void assertOutput(File root) throws Exception {
-		File bundleArchive = new File(root, "test-bundle/target/test-bundle-0.0.1-SNAPSHOT.zip");
+		Path cicsBundle = root.toPath().resolve("test-bundle/target/test-bundle-0.0.1-SNAPSHOT.zip");
 		
-		File tempDir = Files.createTempDirectory("cbmp").toFile();
-		
-		ZipUnArchiver unArchiver = new ZipUnArchiver(bundleArchive);
-		unArchiver.setDestDirectory(tempDir);
-		unArchiver.enableLogging(new ConsoleLogger());
-		unArchiver.extract();
-		
-		String[] files = tempDir.list();
-		assertThat(files, arrayContainingInAnyOrder(META_INF, EBA_BUNDLE_PART, EBA_BUNDLE));
-		
-		List<String> wbpLines = FileUtils.readLines(new File(tempDir, EBA_BUNDLE_PART));
-		assertEquals(2, wbpLines.size());
-		assertTrue(wbpLines.get(0).startsWith("<?xml"));
-		assertTrue(wbpLines.get(0).endsWith("?>"));
-		assertEquals("<ebabundle jvmserver=\"EYUCMCIJ\" symbolicname=\"test-eba-0.0.1-SNAPSHOT\"/>", wbpLines.get(1));
-		
-		File metaInf = new File(tempDir, META_INF);
-		files = metaInf.list();
-		assertEquals(1, files.length);
-		assertEquals(CICS_XML, files[0]);
-		
-		List<String> cxLines = FileUtils.readLines(new File(metaInf, CICS_XML));
-		System.out.println(cxLines);
-		assertEquals(7, cxLines.size());
-		assertTrue(cxLines.get(0).startsWith("<?xml"));
-		assertTrue(cxLines.get(0).endsWith("?>"));
-		assertEquals("<manifest xmlns=\"http://www.ibm.com/xmlns/prod/cics/bundle\" bundleMajorVer=\"0\" bundleMicroVer=\"1\" bundleMinorVer=\"0\" bundleRelease=\"0\" bundleVersion=\"1\" id=\"test-bundle\">", cxLines.get(1));
-		assertEquals("  <meta_directives>", cxLines.get(2));
-		assertTrue(cxLines.get(3).matches("    <timestamp>\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\d.\\d\\d\\dZ</timestamp>"));
-		assertEquals("  </meta_directives>", cxLines.get(4));
-		assertEquals("  <define name=\"test-eba-0.0.1-SNAPSHOT\" path=\"test-eba-0.0.1-SNAPSHOT.ebabundle\" type=\"http://www.ibm.com/xmlns/prod/cics/bundle/EBABUNDLE\"/>", cxLines.get(5));
-		assertEquals("</manifest>", cxLines.get(6));
+		assertBundleContents(
+				cicsBundle,
+				manifestValidator(
+					"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" + 
+					"<manifest xmlns=\"http://www.ibm.com/xmlns/prod/cics/bundle\" bundleMajorVer=\"0\" bundleMicroVer=\"1\" bundleMinorVer=\"0\" bundleRelease=\"0\" bundleVersion=\"1\" id=\"test-bundle\">\n" +
+					"  <meta_directives>\n" +
+					"    <timestamp>2019-09-11T21:12:17.023Z</timestamp>\n" +
+					"  </meta_directives>\n" +
+					"  <define name=\"test-eba-0.0.1-SNAPSHOT\" path=\"test-eba-0.0.1-SNAPSHOT.ebabundle\" type=\"http://www.ibm.com/xmlns/prod/cics/bundle/EBABUNDLE\"/>\n" +
+					"</manifest>"
+				),
+				bfv(
+					EBA_BUNDLE_PART,
+					is -> assertThat(
+						is,
+						CompareMatcher.isIdenticalTo(
+							"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + 
+							"<ebabundle jvmserver=\"EYUCMCIJ\" symbolicname=\"test-eba-0.0.1-SNAPSHOT\"/>"
+						)
+					)
+				),
+				bfv(
+					EBA_BUNDLE,
+					is -> {}
+				)
+			);
 	}
 	
 }

--- a/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildWar.java
+++ b/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildWar.java
@@ -1,5 +1,4 @@
 package com.ibm.cics.cbmp;
-
 /*-
  * #%L
  * CICS Bundle Maven Plugin
@@ -14,62 +13,51 @@ package com.ibm.cics.cbmp;
  * #L%
  */
 
-import static org.hamcrest.collection.ArrayMatching.arrayContainingInAnyOrder;
-import static org.junit.Assert.assertEquals;
+import static com.ibm.cics.cbmp.BundleValidator.assertBundleContents;
+import static com.ibm.cics.cbmp.BundleValidator.bfv;
+import static com.ibm.cics.cbmp.BundleValidator.manifestValidator;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 import java.io.File;
-import java.nio.file.Files;
-import java.util.List;
+import java.nio.file.Path;
 
-import org.apache.commons.io.FileUtils;
-import org.codehaus.plexus.archiver.zip.ZipUnArchiver;
-import org.codehaus.plexus.logging.console.ConsoleLogger;
+import org.xmlunit.matchers.CompareMatcher;
 
 public class PostBuildWar {
 
-	private static final String CICS_XML = "cics.xml";
-	private static final String META_INF = "META-INF";
-	private static final String BASE_NAME = "test-war-1.0.0";
+	private static final String BASE_NAME = "/test-war-1.0.0";
 	private static final String WAR_BUNDLE_PART = BASE_NAME + ".warbundle";
 	private static final String WAR_BUNDLE = BASE_NAME + ".war";
 
 	static void assertOutput(File root) throws Exception {
-		File bundleArchive = new File(root, "test-bundle/target/test-bundle-0.0.1-SNAPSHOT.zip");
+		Path cicsBundle = root.toPath().resolve("test-bundle/target/test-bundle-0.0.1-SNAPSHOT.zip");
 		
-		File tempDir = Files.createTempDirectory("cbmp").toFile();
-		
-		ZipUnArchiver unArchiver = new ZipUnArchiver(bundleArchive);
-		unArchiver.setDestDirectory(tempDir);
-		unArchiver.enableLogging(new ConsoleLogger());
-		unArchiver.extract();
-		
-		String[] files = tempDir.list();
-		assertThat(files, arrayContainingInAnyOrder(META_INF, WAR_BUNDLE_PART, WAR_BUNDLE));
-		
-		List<String> wbpLines = FileUtils.readLines(new File(tempDir, WAR_BUNDLE_PART));
-		assertEquals(2, wbpLines.size());
-		assertTrue(wbpLines.get(0).startsWith("<?xml"));
-		assertTrue(wbpLines.get(0).endsWith("?>"));
-		assertEquals("<warbundle jvmserver=\"EYUCMCIJ\" symbolicname=\"test-war-1.0.0\"/>", wbpLines.get(1));
-		
-		File metaInf = new File(tempDir, META_INF);
-		files = metaInf.list();
-		assertEquals(1, files.length);
-		assertEquals(CICS_XML, files[0]);
-		
-		List<String> cxLines = FileUtils.readLines(new File(metaInf, CICS_XML));
-		System.out.println(cxLines);
-		assertEquals(7, cxLines.size());
-		assertTrue(cxLines.get(0).startsWith("<?xml"));
-		assertTrue(cxLines.get(0).endsWith("?>"));
-		assertEquals("<manifest xmlns=\"http://www.ibm.com/xmlns/prod/cics/bundle\" bundleMajorVer=\"0\" bundleMicroVer=\"1\" bundleMinorVer=\"0\" bundleRelease=\"0\" bundleVersion=\"1\" id=\"test-bundle\">", cxLines.get(1));
-		assertEquals("  <meta_directives>", cxLines.get(2));
-		assertTrue(cxLines.get(3).matches("    <timestamp>\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\d.\\d\\d\\dZ</timestamp>"));
-		assertEquals("  </meta_directives>", cxLines.get(4));
-		assertEquals("  <define name=\"test-war-1.0.0\" path=\"test-war-1.0.0.warbundle\" type=\"http://www.ibm.com/xmlns/prod/cics/bundle/WARBUNDLE\"/>", cxLines.get(5));
-		assertEquals("</manifest>", cxLines.get(6));
+		assertBundleContents(
+				cicsBundle,
+				manifestValidator(
+					"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" + 
+					"<manifest xmlns=\"http://www.ibm.com/xmlns/prod/cics/bundle\" bundleMajorVer=\"0\" bundleMicroVer=\"1\" bundleMinorVer=\"0\" bundleRelease=\"0\" bundleVersion=\"1\" id=\"test-bundle\">\n" +
+					"  <meta_directives>\n" +
+					"    <timestamp>2019-09-11T21:12:17.023Z</timestamp>\n" +
+					"  </meta_directives>\n" +
+					"  <define name=\"test-war-1.0.0\" path=\"test-war-1.0.0.warbundle\" type=\"http://www.ibm.com/xmlns/prod/cics/bundle/WARBUNDLE\"/>\n" +
+					"</manifest>"
+				),
+				bfv(
+					WAR_BUNDLE_PART,
+					is -> assertThat(
+						is,
+						CompareMatcher.isIdenticalTo(
+							"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + 
+							"<warbundle jvmserver=\"EYUCMCIJ\" symbolicname=\"test-war-1.0.0\"/>"
+						)
+					)
+				),
+				bfv(
+					WAR_BUNDLE,
+					is -> {}
+				)
+			);
 	}
 	
 }

--- a/cics-bundle-reactor-archetype/src/main/resources/archetype-resources/__rootArtifactId__-war/pom.xml
+++ b/cics-bundle-reactor-archetype/src/main/resources/archetype-resources/__rootArtifactId__-war/pom.xml
@@ -14,12 +14,32 @@
   <packaging>war</packaging>
   <name>Example web application</name>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.ibm.cics</groupId>
+        <artifactId>com.ibm.cics.ts.bom</artifactId>
+        <!--
+          Change to a version that matches your release of CICS TS.
+          See https://repo1.maven.org/maven2/com/ibm/cics/com.ibm.cics.ts.bom/ for available versions.
+        -->
+        <version>LATEST</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <version>3.1.0</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.ibm.cics</groupId>
+      <artifactId>com.ibm.cics.server</artifactId>
     </dependency>
   </dependencies>
 

--- a/cics-bundle-reactor-archetype/src/main/resources/archetype-resources/__rootArtifactId__-war/src/main/java/com/example/servlet/HelloServlet.java
+++ b/cics-bundle-reactor-archetype/src/main/resources/archetype-resources/__rootArtifactId__-war/src/main/java/com/example/servlet/HelloServlet.java
@@ -8,6 +8,8 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.ibm.cics.server.Task;
+
 @WebServlet("/hello")
 public class HelloServlet extends HttpServlet {
 
@@ -18,7 +20,7 @@ public class HelloServlet extends HttpServlet {
 			throws ServletException, IOException {
 		response.setContentType("application/json");
 
-		response.getWriter().print("{\"message\": \"Hello World! This message is provided by HelloServlet.\"}");
+		response.getWriter().print("{\"message\": \"Hello World! This message is provided by HelloServlet, running on CICS task " + Task.getTask().getTaskNumber() + ".\"}");
 	}
 
 }


### PR DESCRIPTION
This pull requests adds reference to JCICS from the archetypes, to make it clearer how to do that.

I also found that the integration tests were unreliable for me, and I think it was because of the change of JRE. I've altered them to be more resilient to that sort of change, by doing XML-style comparison and another couple of changes.

I've also reduced the number of warnings emitted by the integration tests by giving plugins explicit version numbers.