### PR TITLE
Rename master to main

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,10 +14,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master, "*" ]
+    branches: [ main, "*" ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ main ]
   schedule:
     - cron: '45 18 * * 0'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ deploy:
   keep_history: true
   local-dir: target/staging/cics-bundle-maven-plugin
   on:
-    branch: master
+    branch: main
 env:
   global:
   - secure: Mbz75ASqQi/bnYa3tO9fH4hTzuEcCG5odCb6QcGWBM5ENuJX/TB/UDOODHD1HuFhD26Jwdo8lx5dzpQ6pmlHpjf1xCEAVljyxYUNQz5Rtq81S/HSG2834ytAeFQiDW/qi9wSL3XEiqyEsAwbc+lbcxzfnb4JYIXVO0uYbLBU8O/WsW0SyrHx/ZZoAsUwUabIdoCT/Wxwnf7SgrC2Q9jpEetILq3gEHbAC8Vrq9cHn0N+EVChxzKmy3pPcGtN3StVVcY3be1qrgjcXd3c0r2vTDF77ydj65FochFu5DwHjo79jVFSpz6VJM7dMelMBEmWEbYbbtxwcpApSTKSizdBh4yMwh5aiZZmrUMzVktjdp+U22tGMyMCOmHhJzyBkRHVn3B9jRLmzAW7fGPExFM2S+6Cw2xF49Zk8NpeQ+MYtOPKBWnP68Y2XRFZx4IiQu5PBBf2/SFuVq4tb6o2v7udjlKPMDCe+uSmpHzgUrfDlKe0vNp3qxVHDwxn/vXwkiFa+T3Bn8jxyhRiHYxeewexqo2gTYsjM263PZ5w1lWbwdZ2kGhqUfL7WXnyFAkI4xmLiDKahH9xPE2OJASwnEiA0L7b7dDISEKXdr6IXOOJCMakKt6CvACub+XaOvrXlkTTwVZwBEW5ZA3H0/1eKfiMOQkoN/gCiAagF8HZnBT/hEA=

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -x
 
-# If this is a master build then deploy at the end
-if [ "$TRAVIS_BRANCH" = 'master' ] && [ "$TRAVIS_PULL_REQUEST" == 'false' ]; then
+# If this is a main build then deploy at the end
+if [ "$TRAVIS_BRANCH" = 'main' ] && [ "$TRAVIS_PULL_REQUEST" == 'false' ]; then
   mvn -Dstyle.color=always -B -U -P sign --settings travis-settings.xml deploy &&
   mvn site site:stage post-site;
 # Otherwise just build and test

--- a/.travis/setup-signing.sh
+++ b/.travis/setup-signing.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -x
 
-# If this is a master build then lay out signing information
-if [ "$TRAVIS_BRANCH" = 'master' ] && [ "$TRAVIS_PULL_REQUEST" == 'false' ]; then
+# If this is a main build then lay out signing information
+if [ "$TRAVIS_BRANCH" = 'main' ] && [ "$TRAVIS_PULL_REQUEST" == 'false' ]; then
   openssl aes-256-cbc -K $encrypted_1e42ed2d98cb_key -iv $encrypted_1e42ed2d98cb_iv -in .travis/signingkey.asc.enc -out .travis/signingkey.asc -d
   gpg --version
   gpg --fast-import .travis/signingkey.asc

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The table of contents is manually created and relies on the wording of the headi
 
 -->
 
-# cics-bundle-maven [![Maven Central Latest](https://maven-badges.herokuapp.com/maven-central/com.ibm.cics/cics-bundle-maven-plugin/badge.svg)](https://search.maven.org/search?q=g:com.ibm.cics%20AND%20a:cics-bundle-maven-plugin) [![Build Status](https://travis-ci.com/IBM/cics-bundle-maven.svg?branch=master)](https://travis-ci.com/IBM/cics-bundle-maven) [![Nexus Snapshots](https://img.shields.io/nexus/s/com.ibm.cics/cics-bundle-maven.svg?server=https%3A%2F%2Foss.sonatype.org&label=snapshot&color=success)](https://oss.sonatype.org/#nexus-search;gav~com.ibm.cics~cics-bundle-maven-plugin~~~)
+# cics-bundle-maven [![Maven Central Latest](https://maven-badges.herokuapp.com/maven-central/com.ibm.cics/cics-bundle-maven-plugin/badge.svg)](https://search.maven.org/search?q=g:com.ibm.cics%20AND%20a:cics-bundle-maven-plugin) [![Build Status](https://travis-ci.com/IBM/cics-bundle-maven.svg?branch=main)](https://travis-ci.com/IBM/cics-bundle-maven) [![Nexus Snapshots](https://img.shields.io/nexus/s/com.ibm.cics/cics-bundle-maven.svg?server=https%3A%2F%2Foss.sonatype.org&label=snapshot&color=success)](https://oss.sonatype.org/#nexus-search;gav~com.ibm.cics~cics-bundle-maven-plugin~~~)
 
 
  - [About this project](#about-this-project)
@@ -261,11 +261,11 @@ Snapshot builds are published to the Sonatype OSS Maven snapshots repository whi
 
 Use of this plugin will vary depending on what you're starting with and the structure of your project. We have included some samples to demonstrate the different methods.
 
-- [Reactor sample](https://github.com/IBM/cics-bundle-maven/tree/master/samples/bundle-reactor-deploy)  
+- [Reactor sample](https://github.com/IBM/cics-bundle-maven/tree/main/samples/bundle-reactor-deploy)  
 This sample is the best starting place if you don't already have a Java project you want to build and want to have a go at building and deploying straight away. This is a reactor project with one module including the source for a web page (including a JCICS call), which will be packaged into a WAR. It has a second module, which creates the bundle and installs this in CICS.
 Further information can be found [here](samples/bundle-reactor-deploy/README.md)
 
-- [WAR sample](https://github.com/IBM/cics-bundle-maven/tree/master/samples/bundle-war-deploy)  
+- [WAR sample](https://github.com/IBM/cics-bundle-maven/tree/main/samples/bundle-war-deploy)  
 This sample shows how you can add to the pom of an existing Java Maven project, to build it into a bundle and install it in CICS.
 Further information can be found [here](samples/bundle-war-deploy/README.md)
 


### PR DESCRIPTION
This changes build and other references to the `master` branch to use `main` instead.