### PR TITLE
Downgraded some of the plugins from milestones to releases

### DIFF
--- a/cics-bundle-maven-plugin/pom.xml
+++ b/cics-bundle-maven-plugin/pom.xml
@@ -225,7 +225,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M5</version>
+          <version>2.22.2</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
             <dependency>
                 <groupId>org.apache.maven.doxia</groupId>
                 <artifactId>doxia-module-markdown</artifactId>
-                <version>2.0.0-M1</version>
+                <version>1.11.1</version>
             </dependency>
         </dependencies>
         <configuration>
@@ -179,7 +179,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>3.0.0-M2</version>
+          <version>3.0.0-M1</version>
         </plugin>
         <plugin>
           <artifactId>maven-install-plugin</artifactId>


### PR DESCRIPTION
maven-deploy-plugin and maven-install-plugin were agreed with Stew to be left at 3.0.0-M1 as that looks to be a major milestone/release
