### PR TITLE
Revert to mainline GitHub action because actions/setup-java#226 merged

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Java
-        uses: bjhargrave/setup-java@a1600c1f88a7741e2420b0a657f2838cec4f09c5
+        uses: actions/setup-java@v2
         with:
           java-version: '8'
           distribution: 'temurin'

--- a/.github/workflows/maven-scheduled-build.yml
+++ b/.github/workflows/maven-scheduled-build.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Java
-        uses: bjhargrave/setup-java@a1600c1f88a7741e2420b0a657f2838cec4f09c5
+        uses: actions/setup-java@v2
         with:
           java-version: '8'
           distribution: 'temurin'


### PR DESCRIPTION
We temporarily used an alternative action to allow GPG subkeys when signing.

actions/setup-java#226 merged and we can revert to the original.