### PR TITLE
Remove working directory when running single-module mojos

### DIFF
--- a/cics-bundle-maven-plugin/src/it/test-repeat-bundle-war/invoker.properties
+++ b/cics-bundle-maven-plugin/src/it/test-repeat-bundle-war/invoker.properties
@@ -1,0 +1,17 @@
+###
+# #%L
+# CICS Bundle Maven Plugin
+# %%
+# Copyright (C) 2022 IBM Corp.
+# %%
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+# #L%
+###
+# We run the build more than once by using the xxx.N syntax for any property.
+# We don't actually want to change the properties, just run it twice.
+invoker.profiles.1=
+invoker.profiles.2=

--- a/cics-bundle-maven-plugin/src/it/test-repeat-bundle-war/pom.xml
+++ b/cics-bundle-maven-plugin/src/it/test-repeat-bundle-war/pom.xml
@@ -1,0 +1,71 @@
+<!--
+  #%L
+  CICS Bundle Maven Plugin
+  %%
+  Copyright (C) 2022 IBM Corp.
+  %%
+  This program and the accompanying materials are made
+  available under the terms of the Eclipse Public License 2.0
+  which is available at https://www.eclipse.org/legal/epl-2.0/
+  
+  SPDX-License-Identifier: EPL-2.0
+  #L%
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.ibm.cics.test-bundle-war</groupId>
+  <artifactId>test-repeat-bundle-war</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>war</packaging>
+  
+  <dependencies>
+    <!-- provided -->
+    <dependency>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>javax.ws.rs-api</artifactId>
+      <version>2.0</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <version>3.2.3</version>
+        <configuration>
+          <failOnMissingWebXml>false</failOnMissingWebXml>
+          <packagingExcludes>pom.xml</packagingExcludes>
+          <warName>test-war</warName>
+        </configuration>
+      </plugin>
+      
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.5.1</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+      
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>bundle-war</goal>
+            </goals>
+            <configuration>
+              <jvmserver>EYUCMCIJ</jvmserver>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  
+</project>

--- a/cics-bundle-maven-plugin/src/it/test-repeat-bundle-war/src/main/java/test_war/TestEndpoint.java
+++ b/cics-bundle-maven-plugin/src/it/test-repeat-bundle-war/src/main/java/test_war/TestEndpoint.java
@@ -1,0 +1,39 @@
+package test_war;
+
+/*-
+ * #%L
+ * CICS Bundle Maven Plugin
+ * %%
+ * Copyright (C) 2022 IBM Corp.
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import java.util.Optional;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@ApplicationPath("")
+@Path("")
+public class TestEndpoint extends javax.ws.rs.core.Application {
+	
+	public TestEndpoint() {
+	}
+
+	@GET
+	@Produces(MediaType.APPLICATION_OCTET_STREAM)
+	public Response get() {
+		return Response.ok().build();
+	}
+	
+}

--- a/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/AbstractBundleJavaMojo.java
+++ b/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/AbstractBundleJavaMojo.java
@@ -15,8 +15,10 @@ package com.ibm.cics.cbmp;
  */
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -64,6 +66,18 @@ public abstract class AbstractBundleJavaMojo extends AbstractBundlePublisherMojo
 
 	@Override
 	public void execute() throws MojoExecutionException, MojoFailureException {
+		
+		if (workDir.exists()) {
+			getLog().debug("Deleting " + workDir);
+			try {
+				FileUtils.deleteDirectory(workDir);
+			} catch (IOException e) {
+				throw new MojoExecutionException("Unable to delete CICS bundle output directory " + workDir, e);
+			}
+		}
+		
+		workDir.mkdirs();
+		
 		BundlePublisher bundlePublisher = getBundlePublisher();
 		
 		Artifact artifact = project.getArtifact();


### PR DESCRIPTION
If the single-module mojos (any that inherit `AbstractBundleJavaMojo`) are run more than once without cleaning, they fail to overwrite existing files in the working directory.

Fixes #191.

First commit has a test and should fail... second commit has the fix.