### PR TITLE
Adds VersionRange support

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ To create a CICS bundle in this way:
         <groupId>my.group.id</groupId>
         <artifactId>my-web-project</artifactId>
         <version>1.0.0</version>
+        <!-- Version ranges are also supported CICS phase in support with OSGi bundles i.e. -->
+        <!-- <version>[1.0.0,2.0.0)</version> -->
         <type>war</type>
       </dependency>
     </dependencies>

--- a/cics-bundle-maven-plugin/pom.xml
+++ b/cics-bundle-maven-plugin/pom.xml
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.ibm.cics</groupId>
       <artifactId>cics-bundle-common</artifactId>
-      <version>1.0.4</version>
+      <version>1.0.5-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.sonatype.plexus</groupId>

--- a/cics-bundle-maven-plugin/src/it/test-bundle-deploy-neither/pom.xml
+++ b/cics-bundle-maven-plugin/src/it/test-bundle-deploy-neither/pom.xml
@@ -2,7 +2,7 @@
   #%L
   CICS Bundle Maven Plugin
   %%
-  Copyright (C) 2019,2022 IBM Corp.
+  Copyright (C) 2019 - 2022 IBM Corp.
   %%
   This program and the accompanying materials are made
   available under the terms of the Eclipse Public License 2.0

--- a/cics-bundle-maven-plugin/src/it/test-bundle-deploy-noCICSplex/pom.xml
+++ b/cics-bundle-maven-plugin/src/it/test-bundle-deploy-noCICSplex/pom.xml
@@ -2,7 +2,7 @@
   #%L
   CICS Bundle Maven Plugin
   %%
-  Copyright (C) 2019,2022 IBM Corp.
+  Copyright (C) 2019 - 2022 IBM Corp.
   %%
   This program and the accompanying materials are made
   available under the terms of the Eclipse Public License 2.0

--- a/cics-bundle-maven-plugin/src/it/test-bundle-deploy-noRegion/pom.xml
+++ b/cics-bundle-maven-plugin/src/it/test-bundle-deploy-noRegion/pom.xml
@@ -2,7 +2,7 @@
   #%L
   CICS Bundle Maven Plugin
   %%
-  Copyright (C) 2019,2022 IBM Corp.
+  Copyright (C) 2019 - 2022 IBM Corp.
   %%
   This program and the accompanying materials are made
   available under the terms of the Eclipse Public License 2.0

--- a/cics-bundle-maven-plugin/src/it/test-bundle-osgi-versionrange/bundle/pom.xml
+++ b/cics-bundle-maven-plugin/src/it/test-bundle-osgi-versionrange/bundle/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.ibm.cics.test-bundle-osgi-versionrange</groupId>
+        <artifactId>test-bundle-osgi-versionrange</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+
+    <groupId>com.ibm.cics.test-bundle-osgi-versionrange</groupId>
+    <artifactId>bundle</artifactId>
+    <version>1.0</version>
+    <packaging>cics-bundle</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.ibm.cics.test-bundle-osgi-versionrange</groupId>
+            <artifactId>osgi</artifactId>
+            <version>[1.0, 2.0)</version>
+            <type>jar</type>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/cics-bundle-maven-plugin/src/it/test-bundle-osgi-versionrange/bundle/pom.xml
+++ b/cics-bundle-maven-plugin/src/it/test-bundle-osgi-versionrange/bundle/pom.xml
@@ -1,4 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  CICS Bundle Maven Plugin
+  %%
+  Copyright (C) 2023 IBM Corp.
+  %%
+  This program and the accompanying materials are made
+  available under the terms of the Eclipse Public License 2.0
+  which is available at https://www.eclipse.org/legal/epl-2.0/
+  
+  SPDX-License-Identifier: EPL-2.0
+  #L%
+  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/cics-bundle-maven-plugin/src/it/test-bundle-osgi-versionrange/osgi/pom.xml
+++ b/cics-bundle-maven-plugin/src/it/test-bundle-osgi-versionrange/osgi/pom.xml
@@ -43,9 +43,9 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <Bundle-SymbolicName>${pom.groupId}.${pom.artifactId}</Bundle-SymbolicName>
-                        <Bundle-Name>${pom.artifactId}</Bundle-Name>
-                        <Bundle-Version>${pom.version}</Bundle-Version>
+                        <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Bundle-Version>${project.version}</Bundle-Version>
                         <Private-Package>com.ibm.cics</Private-Package>
                     </instructions>
                 </configuration>

--- a/cics-bundle-maven-plugin/src/it/test-bundle-osgi-versionrange/osgi/pom.xml
+++ b/cics-bundle-maven-plugin/src/it/test-bundle-osgi-versionrange/osgi/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.ibm.cics.test-bundle-osgi-versionrange</groupId>
+        <artifactId>test-bundle-osgi-versionrange</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+
+
+    <groupId>com.ibm.cics.test-bundle-osgi-versionrange</groupId>
+    <artifactId>osgi</artifactId>
+    <version>1.0</version>
+    <packaging>bundle</packaging>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>1.4.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${pom.groupId}.${pom.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${pom.artifactId}</Bundle-Name>
+                        <Bundle-Version>${pom.version}</Bundle-Version>
+                        <Private-Package>com.ibm.cics</Private-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/cics-bundle-maven-plugin/src/it/test-bundle-osgi-versionrange/osgi/pom.xml
+++ b/cics-bundle-maven-plugin/src/it/test-bundle-osgi-versionrange/osgi/pom.xml
@@ -1,4 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  CICS Bundle Maven Plugin
+  %%
+  Copyright (C) 2023 IBM Corp.
+  %%
+  This program and the accompanying materials are made
+  available under the terms of the Eclipse Public License 2.0
+  which is available at https://www.eclipse.org/legal/epl-2.0/
+  
+  SPDX-License-Identifier: EPL-2.0
+  #L%
+  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/cics-bundle-maven-plugin/src/it/test-bundle-osgi-versionrange/osgi/src/main/java/com/ibm/cics/Main.java
+++ b/cics-bundle-maven-plugin/src/it/test-bundle-osgi-versionrange/osgi/src/main/java/com/ibm/cics/Main.java
@@ -1,3 +1,17 @@
+/*-
+ * #%L
+ * CICS Bundle Maven Plugin
+ * %%
+ * Copyright (C) 2019, 2023 IBM Corp.
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
 package com.ibm.cics;
 
 public class Main {

--- a/cics-bundle-maven-plugin/src/it/test-bundle-osgi-versionrange/osgi/src/main/java/com/ibm/cics/Main.java
+++ b/cics-bundle-maven-plugin/src/it/test-bundle-osgi-versionrange/osgi/src/main/java/com/ibm/cics/Main.java
@@ -2,7 +2,7 @@
  * #%L
  * CICS Bundle Maven Plugin
  * %%
- * Copyright (C) 2019, 2023 IBM Corp.
+ * Copyright (C) 2019 - 2023 IBM Corp.
  * %%
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/cics-bundle-maven-plugin/src/it/test-bundle-osgi-versionrange/osgi/src/main/java/com/ibm/cics/Main.java
+++ b/cics-bundle-maven-plugin/src/it/test-bundle-osgi-versionrange/osgi/src/main/java/com/ibm/cics/Main.java
@@ -1,0 +1,7 @@
+package com.ibm.cics;
+
+public class Main {
+    public static void main(String[] args) {
+        System.out.println("Hello world!");
+    }
+}

--- a/cics-bundle-maven-plugin/src/it/test-bundle-osgi-versionrange/pom.xml
+++ b/cics-bundle-maven-plugin/src/it/test-bundle-osgi-versionrange/pom.xml
@@ -1,0 +1,28 @@
+<!--
+  #%L
+  CICS Bundle Maven Plugin
+  %%
+  Copyright (C) 2019 IBM Corp.
+  %%
+  This program and the accompanying materials are made
+  available under the terms of the Eclipse Public License 2.0
+  which is available at https://www.eclipse.org/legal/epl-2.0/
+
+  SPDX-License-Identifier: EPL-2.0
+  #L%
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.ibm.cics.test-bundle-osgi-versionrange</groupId>
+    <artifactId>test-bundle-osgi-versionrange</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>osgi</module>
+        <module>bundle</module>
+    </modules>
+
+</project>

--- a/cics-bundle-maven-plugin/src/it/test-bundle-osgi-versionrange/postbuild.bsh
+++ b/cics-bundle-maven-plugin/src/it/test-bundle-osgi-versionrange/postbuild.bsh
@@ -1,0 +1,1 @@
+com.ibm.cics.cbmp.PostBuildTestBundleOSGiVersionRange.assertOutput(basedir);

--- a/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/BundleDeployMojo.java
+++ b/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/BundleDeployMojo.java
@@ -4,7 +4,7 @@ package com.ibm.cics.cbmp;
  * #%L
  * CICS Bundle Maven Plugin
  * %%
- * Copyright (C) 2019,2022 IBM Corp.
+ * Copyright (C) 2019 - 2022 IBM Corp.
  * %%
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/Osgibundle.java
+++ b/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/Osgibundle.java
@@ -53,23 +53,23 @@ public class Osgibundle extends AbstractJavaBundlePartBinding {
 	
 	@Override
 	public OsgiBundlePart toBundlePartImpl() throws MojoExecutionException {
-		return new OsgiBundlePart(
+		OsgiBundlePart bundlePart = new OsgiBundlePart(
 			getName(),
 			symbolicName,
 			osgiVersion,
 			getJvmserver(),
-			resolvedArtifact.getFile(),
-			getVersionrange()
+			resolvedArtifact.getFile()
 		);
+		bundlePart.setVersionRange(getVersionRange());
+		return bundlePart;
 	}
 
-	public String getVersionrange() {
-		if(resolvedArtifact.getVersionRange().toString().contains(",")) {
+	public String getVersionRange() {
+		if(resolvedArtifact.getVersionRange() != null && resolvedArtifact.getVersionRange().toString().contains(",")) {
 			return resolvedArtifact.getVersionRange().toString();
 		} else {
 			return "";
 		}
-
 	}
 
 }

--- a/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/Osgibundle.java
+++ b/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/Osgibundle.java
@@ -10,7 +10,7 @@ import com.ibm.cics.bundle.parts.OsgiBundlePart;
  * #%L
  * CICS Bundle Maven Plugin
  * %%
- * Copyright (C) 2019, 2023 IBM Corp.
+ * Copyright (C) 2019 - 2023 IBM Corp.
  * %%
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/Osgibundle.java
+++ b/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/Osgibundle.java
@@ -10,7 +10,7 @@ import com.ibm.cics.bundle.parts.OsgiBundlePart;
  * #%L
  * CICS Bundle Maven Plugin
  * %%
- * Copyright (C) 2019 IBM Corp.
+ * Copyright (C) 2019, 2023 IBM Corp.
  * %%
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/Osgibundle.java
+++ b/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/Osgibundle.java
@@ -58,8 +58,18 @@ public class Osgibundle extends AbstractJavaBundlePartBinding {
 			symbolicName,
 			osgiVersion,
 			getJvmserver(),
-			resolvedArtifact.getFile()
+			resolvedArtifact.getFile(),
+			getVersionrange()
 		);
+	}
+
+	public String getVersionrange() {
+		if(resolvedArtifact.getVersionRange().toString().contains(",")) {
+			return resolvedArtifact.getVersionRange().toString();
+		} else {
+			return "";
+		}
+
 	}
 
 }

--- a/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildOsgi.java
+++ b/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildOsgi.java
@@ -31,9 +31,12 @@ public class PostBuildOsgi {
 
 	private static final String BND_SYMBOLIC_NAME = "test-osgi";
 	private static final String TYCHO_SYMBOLIC_NAME = "test-tycho";
+	private static final String BND_SYMBOLIC_NAME_VR= "test-osgi-versionrange";
 	private static final String VERSION = "0.0.1-SNAPSHOT";
+	private static final String VERSION_NOSNAP = "1.0";
 	private static final String BUNDLE_PART_EXT_REGEX = "\\.osgibundle";
 	private static final String BUNDLE_EXT_REGEX = "\\.jar";
+	private static final String BND_VR_BUNDLE_REGEX = "\\/" + BND_SYMBOLIC_NAME_VR + "-" + VERSION + BUNDLE_PART_EXT_REGEX;
 	private static final String BND_BUNDLE_PART_REGEX = "\\/" + BND_SYMBOLIC_NAME + "-" + VERSION + BUNDLE_PART_EXT_REGEX;
 	private static final String TYCHO_BUNDLE_PART_REGEX = "\\/" + TYCHO_SYMBOLIC_NAME + "-" + VERSION + BUNDLE_PART_EXT_REGEX;
 	private static final String BND_BUNDLE_REGEX = "\\/" + BND_SYMBOLIC_NAME + "-" + VERSION + BUNDLE_EXT_REGEX;
@@ -41,7 +44,7 @@ public class PostBuildOsgi {
 
 	static void assertOutput(File root) throws Exception {
 		Path cicsBundle = root.toPath().resolve("test-bundle/target/test-bundle-0.0.1-SNAPSHOT.zip");
-		
+
 		assertBundleContents(
 				cicsBundle,
 				manifestWithOSGiVersionsValidator(
@@ -85,11 +88,30 @@ public class PostBuildOsgi {
 					)
 				),
 				bfmv(
+						BND_VR_BUNDLE_REGEX,
+						is -> assertThat(
+								is,
+								CompareMatcher.isIdenticalTo(
+										"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+												"<osgibundle jvmserver=\"EYUCMCIJ\" symbolicname=\"test-osgi-versionrange\" version=\"0.0.1.201912132301\"/>"
+								).withDifferenceEvaluator(
+										DifferenceEvaluators.chain(
+												DifferenceEvaluators.Default,
+												OSGI_VERSION_EVALUATOR
+										)
+								)
+						)
+				),
+				bfmv(
 					BND_BUNDLE_REGEX,
 					is -> {}
 				),
 				bfmv(
 					TYCHO_BUNDLE_REGEX,
+					is -> {}
+				),
+				bfmv(
+					BND_VR_BUNDLE_REGEX,
 					is -> {}
 				)
 			);

--- a/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildOsgi.java
+++ b/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildOsgi.java
@@ -3,7 +3,7 @@ package com.ibm.cics.cbmp;
  * #%L
  * CICS Bundle Maven Plugin
  * %%
- * Copyright (C) 2019 IBM Corp.
+ * Copyright (C) 2019, 2023 IBM Corp.
  * %%
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -33,7 +33,6 @@ public class PostBuildOsgi {
 	private static final String TYCHO_SYMBOLIC_NAME = "test-tycho";
 	private static final String BND_SYMBOLIC_NAME_VR= "test-osgi-versionrange";
 	private static final String VERSION = "0.0.1-SNAPSHOT";
-	private static final String VERSION_NOSNAP = "1.0";
 	private static final String BUNDLE_PART_EXT_REGEX = "\\.osgibundle";
 	private static final String BUNDLE_EXT_REGEX = "\\.jar";
 	private static final String BND_VR_BUNDLE_REGEX = "\\/" + BND_SYMBOLIC_NAME_VR + "-" + VERSION + BUNDLE_PART_EXT_REGEX;

--- a/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildOsgi.java
+++ b/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildOsgi.java
@@ -3,7 +3,7 @@ package com.ibm.cics.cbmp;
  * #%L
  * CICS Bundle Maven Plugin
  * %%
- * Copyright (C) 2019, 2023 IBM Corp.
+ * Copyright (C) 2019 - 2023 IBM Corp.
  * %%
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildTestBundleOSGiVersionRange.java
+++ b/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildTestBundleOSGiVersionRange.java
@@ -1,0 +1,64 @@
+package com.ibm.cics.cbmp;
+
+import org.xmlunit.diff.DifferenceEvaluators;
+import org.xmlunit.matchers.CompareMatcher;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import static com.ibm.cics.cbmp.BundleValidator.*;
+import static org.junit.Assert.assertThat;
+
+/*-
+ * #%L
+ * CICS Bundle Maven Plugin
+ * %%
+ * Copyright (C) 2019 IBM Corp.
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+public class PostBuildTestBundleOSGiVersionRange {
+	
+	static void assertOutput(File root) throws Exception {
+		Path cicsBundle = root.toPath().resolve("bundle/target/bundle-1.0.zip");
+
+		assertBundleContents(
+			cicsBundle,
+			manifestValidator(
+				"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
+						"<manifest xmlns=\"http://www.ibm.com/xmlns/prod/cics/bundle\" bundleMajorVer=\"1\" bundleMicroVer=\"0\" bundleMinorVer=\"0\" bundleRelease=\"0\" bundleVersion=\"1\" id=\"bundle\">\n" +
+						"  <meta_directives>\n" +
+						"    <timestamp>2023-01-17T15:00:32.038Z</timestamp>\n" +
+						"  </meta_directives>\n" +
+						"  <define name=\"osgi-1.0\" path=\"osgi-1.0.osgibundle\" type=\"http://www.ibm.com/xmlns/prod/cics/bundle/OSGIBUNDLE\"/>\n" +
+						"</manifest>\n"
+			),
+			bfv(
+				"/osgi-1.0.osgibundle",
+				is -> assertThat(
+					is,
+					CompareMatcher.isIdenticalTo(
+						"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" + 
+						"<osgibundle jvmserver=\"MYJVMS\" symbolicname=\"com.ibm.cics.test-bundle-osgi-versionrange.osgi\" versionrange=\"[1.0,2.0)\"/>"
+					).withDifferenceEvaluator(
+						DifferenceEvaluators.chain(
+							DifferenceEvaluators.Default,
+							OSGI_VERSION_EVALUATOR
+						)
+					)
+				)
+			),
+			bfv(
+				"/osgi-1.0.jar",
+				is -> {}
+			)
+		);
+	}
+
+}

--- a/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildTestBundleOSGiVersionRange.java
+++ b/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildTestBundleOSGiVersionRange.java
@@ -13,7 +13,7 @@ import static org.junit.Assert.assertThat;
  * #%L
  * CICS Bundle Maven Plugin
  * %%
- * Copyright (C) 2019, 2023 IBM Corp.
+ * Copyright (C) 2019 - 2023 IBM Corp.
  * %%
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildTestBundleOSGiVersionRange.java
+++ b/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildTestBundleOSGiVersionRange.java
@@ -45,7 +45,7 @@ public class PostBuildTestBundleOSGiVersionRange {
 					is,
 					CompareMatcher.isIdenticalTo(
 						"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" + 
-						"<osgibundle jvmserver=\"MYJVMS\" symbolicname=\"com.ibm.cics.test-bundle-osgi-versionrange.osgi\" versionrange=\"[1.0,2.0)\"/>"
+						"<osgibundle jvmserver=\"MYJVMS\" symbolicname=\"com.ibm.cics.test-bundle-osgi-versionrange.osgi\" version= \"\" versionRange=\"[1.0,2.0)\"/>"
 					).withDifferenceEvaluator(
 						DifferenceEvaluators.chain(
 							DifferenceEvaluators.Default,

--- a/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildTestBundleOSGiVersionRange.java
+++ b/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildTestBundleOSGiVersionRange.java
@@ -13,7 +13,7 @@ import static org.junit.Assert.assertThat;
  * #%L
  * CICS Bundle Maven Plugin
  * %%
- * Copyright (C) 2019 IBM Corp.
+ * Copyright (C) 2019, 2023 IBM Corp.
  * %%
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0


### PR DESCRIPTION
Adds support for VersionRanges in the version field in the POM file. Relies on a change in `cics-bundle-common` to go in before hand.

An example of using the new feature would be defining a dependency on a java project you want to wrap-up using the following code in your pom:

```
    <dependencies>
        <dependency>
            <groupId>com.ibm.cics.test-bundle-osgi-versionrange</groupId>
            <artifactId>osgi</artifactId>
            <version>[1.0, 2.0)</version>
            <type>jar</type>
        </dependency>
    </dependencies>
```