### PR TITLE
Update dependencies

### DIFF
--- a/cics-bundle-maven-plugin/pom.xml
+++ b/cics-bundle-maven-plugin/pom.xml
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.ibm.cics</groupId>
       <artifactId>cics-bundle-common</artifactId>
-      <version>1.0.5-SNAPSHOT</version>
+      <version>2.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.sonatype.plexus</groupId>
@@ -30,17 +30,17 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-archiver</artifactId>
-      <version>4.2.7</version>
+      <version>4.6.3</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>3.4.1</version>
+      <version>3.5.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
-      <version>3.5.4</version>
+      <version>3.9.1</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -53,22 +53,22 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>31.0.1-jre</version>
+      <version>31.1-jre</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.mojo</groupId>
       <artifactId>build-helper-maven-plugin</artifactId>
-      <version>3.0.0</version>
+      <version>3.3.0</version>
     </dependency>
 
     <!-- dependencies to annotations -->
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
-      <version>3.6.4</version>
+      <version>3.8.2</version>
       <scope>provided</scope><!-- annotations are needed only to build the plugin -->
     </dependency>
-    
+
     <!-- test -->
     <dependency>
       <groupId>junit</groupId>
@@ -85,19 +85,19 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>4.3.1</version>
+      <version>5.3.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
-      <version>2.32.0</version>
+      <artifactId>wiremock-jre8-standalone</artifactId>
+      <version>2.35.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.xmlunit</groupId>
       <artifactId>xmlunit-matchers</artifactId>
-      <version>2.9.0</version>
+      <version>2.9.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -151,7 +151,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.9.0</version>
+        <version>3.10.1</version>
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
@@ -160,7 +160,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.3.0</version>
         <executions>
           <execution>
             <goals>

--- a/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/AbstractBundlePublisherMojo.java
+++ b/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/AbstractBundlePublisherMojo.java
@@ -64,8 +64,7 @@ public abstract class AbstractBundlePublisherMojo extends AbstractMojo {
 			project.getArtifactId(),
 			v.getMajor(),
 			v.getMinor(),
-			v.getPatch(),
-			v.getBuildNumber()
+			v.getPatch()
 		);
 		
 		//Notify the build context of file changes

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
             <dependency>
                 <groupId>org.apache.maven.doxia</groupId>
                 <artifactId>doxia-module-markdown</artifactId>
-                <version>1.11.1</version>
+                <version>2.0.0</version>
             </dependency>
         </dependencies>
         <configuration>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -62,7 +62,7 @@
         <dependencies>
           <dependency>
             <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock</artifactId>
+            <artifactId>wiremock-standalone</artifactId>
             <version>2.27.2</version>
           </dependency>
         </dependencies>


### PR DESCRIPTION
Updated dependencies. The build-helper dep has changes a returned signature in a update from 3.0.0 to 3.3.0, and therefore the types werent compatible anymore. The VersionInformation object now returns the buildNumber as a long instead of an int. To comabat this, we will leave it be and changed the constructor provided by common to use a long and cast a int to a long in the gradle plugin to conform (which should always be safe)