### PR TITLE
Fix URL for GitHub Pages environment deployment

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -58,4 +58,5 @@ jobs:
 
     steps:
       - name: Deploy site to GitHub Pages
+        id: deployment
         uses: actions/deploy-pages@v1


### PR DESCRIPTION
Wait for #219.

This fixes a warning we see in the workflow that deploys to GitHub Pages - the step 'deployment' is referenced but not declared.