### PR TITLE
Use project.build.finalName to derive artifact name

### DIFF
--- a/cics-bundle-maven-plugin/pom.xml
+++ b/cics-bundle-maven-plugin/pom.xml
@@ -190,6 +190,7 @@
           <addTestClassPath>true</addTestClassPath>
           <goals>install</goals>
           <mergeUserSettings>true</mergeUserSettings>
+          <pomIncludes>test-bundle-war-final-name/pom.xml</pomIncludes>
           <scriptVariables>
             <wiremockPort>${wiremockPort}</wiremockPort>
           </scriptVariables>

--- a/cics-bundle-maven-plugin/src/it/test-bundle-war-final-name/pom.xml
+++ b/cics-bundle-maven-plugin/src/it/test-bundle-war-final-name/pom.xml
@@ -1,0 +1,74 @@
+<!--
+  #%L
+  CICS Bundle Maven Plugin
+  %%
+  Copyright (C) 2024 IBM Corp.
+  %%
+  This program and the accompanying materials are made
+  available under the terms of the Eclipse Public License 2.0
+  which is available at https://www.eclipse.org/legal/epl-2.0/
+  
+  SPDX-License-Identifier: EPL-2.0
+  #L%
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.ibm.cics.test-bundle-war</groupId>
+  <artifactId>test-bundle-war</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>war</packaging>
+  
+  <dependencies>
+    <!-- provided -->
+    <dependency>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>javax.ws.rs-api</artifactId>
+      <version>2.0</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+  
+  <build>
+  
+  	<finalName>${project.artifactId}</finalName>
+  	
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <version>3.2.3</version>
+        <configuration>
+          <failOnMissingWebXml>false</failOnMissingWebXml>
+          <packagingExcludes>pom.xml</packagingExcludes>
+          <warName>test-war</warName>
+        </configuration>
+      </plugin>
+      
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.5.1</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+      
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>bundle-war</goal>
+            </goals>
+            <configuration>
+              <jvmserver>EYUCMCIJ</jvmserver>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  
+</project>

--- a/cics-bundle-maven-plugin/src/it/test-bundle-war-final-name/postbuild.bsh
+++ b/cics-bundle-maven-plugin/src/it/test-bundle-war-final-name/postbuild.bsh
@@ -1,0 +1,1 @@
+com.ibm.cics.cbmp.PostBuildTestBundleWarFinalName.assertOutput(basedir);

--- a/cics-bundle-maven-plugin/src/it/test-bundle-war-final-name/src/main/java/test_war/TestEndpoint.java
+++ b/cics-bundle-maven-plugin/src/it/test-bundle-war-final-name/src/main/java/test_war/TestEndpoint.java
@@ -1,0 +1,39 @@
+package test_war;
+
+/*-
+ * #%L
+ * CICS Bundle Maven Plugin
+ * %%
+ * Copyright (C) 2024 IBM Corp.
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import java.util.Optional;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@ApplicationPath("")
+@Path("")
+public class TestEndpoint extends javax.ws.rs.core.Application {
+	
+	public TestEndpoint() {
+	}
+
+	@GET
+	@Produces(MediaType.APPLICATION_OCTET_STREAM)
+	public Response get() {
+		return Response.ok().build();
+	}
+	
+}

--- a/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/AbstractBundleJavaMojo.java
+++ b/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/AbstractBundleJavaMojo.java
@@ -31,9 +31,6 @@ import com.ibm.cics.bundle.parts.BundlePublisher.PublishException;
 
 public abstract class AbstractBundleJavaMojo extends AbstractBundlePublisherMojo implements DefaultsProvider {
 
-	@Parameter(defaultValue = "${project.build.directory}/${project.artifactId}-${project.version}-cics-bundle.zip", required = true, readonly = true)
-	private File cicsBundleArchive;
-	
 	/**
 	 * The CICS JVM server that the Java code will execute in.
 	 */
@@ -51,6 +48,12 @@ public abstract class AbstractBundleJavaMojo extends AbstractBundlePublisherMojo
 	
 	@Parameter(defaultValue = "${project.build.directory}", required = true, readonly = true)
 	private File buildDir;
+	
+	/**
+	 * The base name to use for the generated bundle archive. 
+	 */
+	@Parameter(property="project.build.finalName", required = true, readonly = true)
+	private String finalName;
 	
 	@Component
 	private MavenProjectHelper projectHelper;
@@ -97,6 +100,7 @@ public abstract class AbstractBundleJavaMojo extends AbstractBundlePublisherMojo
 			bundlePublisher,
 			classifier,
 			project,
+			finalName,
 			projectHelper
 		);
 	}

--- a/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/PackageCICSBundleMojo.java
+++ b/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/PackageCICSBundleMojo.java
@@ -46,6 +46,12 @@ public class PackageCICSBundleMojo extends AbstractAutoConfigureBundlePublisherM
 	 */
 	@Parameter(property="cicsbundle.classifier", required = false, readonly = false)
 	private String classifier;
+	
+	/**
+	 * The base name to use for the generated bundle archive. 
+	 */
+	@Parameter(property="project.build.finalName", required = true, readonly = true)
+	private String finalName;
 
 	@Component
 	private MavenProjectHelper projectHelper;
@@ -62,6 +68,7 @@ public class PackageCICSBundleMojo extends AbstractAutoConfigureBundlePublisherM
 			bundlePublisher,
 			classifier,
 			project,
+			finalName,
 			projectHelper
 		);
 		
@@ -75,13 +82,15 @@ public class PackageCICSBundleMojo extends AbstractAutoConfigureBundlePublisherM
 			BundlePublisher bundlePublisher,
 			String classifier,
 			MavenProject project,
+			String finalName,
 			MavenProjectHelper projectHelper) throws MojoExecutionException {
 		try {
 			bundlePublisher.publishDynamicResources();
 			
 			ZipArchiver zipArchiver = new ZipArchiver();
 			zipArchiver.addDirectory(workDir);
-			File cicsBundle = new File(outputDir, project.getArtifactId() + "-" + project.getVersion() + (classifier != null ? "-" + classifier : "") + "." + CICS_BUNDLE_EXTENSION);
+			
+			File cicsBundle = new File(outputDir, finalName + (classifier != null ? "-" + classifier : "") + "." + CICS_BUNDLE_EXTENSION);
 			zipArchiver.setDestFile(cicsBundle);
 			zipArchiver.createArchive();
 		

--- a/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildTestBundleWarFinalName.java
+++ b/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildTestBundleWarFinalName.java
@@ -1,0 +1,56 @@
+package com.ibm.cics.cbmp;
+
+/*-
+ * #%L
+ * CICS Bundle Maven Plugin
+ * %%
+ * Copyright (C) 2024 IBM Corp.
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static com.ibm.cics.cbmp.BundleValidator.assertBundleContents;
+import static com.ibm.cics.cbmp.BundleValidator.bfv;
+import static com.ibm.cics.cbmp.BundleValidator.manifestValidator;
+
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+
+import org.xmlunit.matchers.CompareMatcher;
+
+public class PostBuildTestBundleWarFinalName {
+	
+	private static final String EXPECTED_MANIFEST = 
+		"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" + 
+		"<manifest xmlns=\"http://www.ibm.com/xmlns/prod/cics/bundle\" bundleMajorVer=\"0\" bundleMicroVer=\"1\" bundleMinorVer=\"0\" bundleRelease=\"0\" bundleVersion=\"1\" id=\"test-bundle-war\">\n" + 
+		"  <meta_directives>\n" + 
+		"    <timestamp>2019-09-10T20:24:32.893Z</timestamp>\n" + 
+		"  </meta_directives>\n" + 
+		"  <define name=\"test-bundle-war-0.0.1-SNAPSHOT\" path=\"test-bundle-war-0.0.1-SNAPSHOT.warbundle\" type=\"http://www.ibm.com/xmlns/prod/cics/bundle/WARBUNDLE\"/>\n" + 
+		"</manifest>";
+	
+	private static final String EXPECTED_BUNDLE_PART = 
+		"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" + 
+		"<warbundle jvmserver=\"EYUCMCIJ\" symbolicname=\"test-bundle-war-0.0.1-SNAPSHOT\"/>";
+	
+	static void assertOutput(File root) throws Exception {
+		assertBundleContents(
+			root.toPath().resolve("target/test-bundle-war-cics-bundle.zip"),
+			manifestValidator(EXPECTED_MANIFEST),
+			bfv(
+				"/test-bundle-war-0.0.1-SNAPSHOT.warbundle",
+				is -> assertThat(is, CompareMatcher.isIdenticalTo(EXPECTED_BUNDLE_PART))
+			),
+			bfv(
+				"/test-bundle-war-0.0.1-SNAPSHOT.war",
+				is -> {}
+			)
+		);
+	}
+}


### PR DESCRIPTION
Fixes #224 

Note that the bundle is now created without a version, as verified by `test-bundle-war-final-name`.  Internally within the bundle zip, the resulting war file will still have a version.

Note that if you're using the `deploy` goal with the bundle deploy API, the resulting bundle directory will still have the version number in, as it's derived from the version in the manifest within the bundle file, not the bundle file name.

This is still useful for scenarios where you're deploying the resulting bundle file yourself though