### PR TITLE
build goal moved to package and major version update

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,21 @@ When you are using a bundle-war, bundle-ear, or bundle-osgi goal, the deploy goa
 **How to resolve it?** 
 Use the <classifier>cics-bundle</classifier> configuration option to select the bundle, in the case where you're deploying a bundle-war-built bundle.
 
+
+### Error reading Bundle-SymbolicName from OSGi manifest file
+**Why does it happen?**  
+You may run into this error when building an OSGi bundle.
+
+The build goal of the Maven Bundle Plugin is bound to the compile phase, but the manifest generation occurs in the process-classes phase, which runs after compile. As a result, if other processes or plugins expect the manifest data during the compile phase, it won't be available yet, leading to errors like "Error reading Bundle-SymbolicName from OSGi manifest file."
+
+**How to resolve it?**  
+
+In Maven Bundle Plugin version 2.0.0 we moved the binding of the build goal from the compile phase to the package phase. This change ensures that the bundle is built as late as possible in the reactor build process, allowing all necessary class files and resources to be fully processed before the manifest is generated.
+
+**Action you must take when upgrading**
+
+If your project uses the cics-bundle packaging type to build any bundle part and you previously used the mvn compile command, you must now use mvn package instead.This change ensures that your bundle parts are packaged correctly with version 2.0.0.
+
 ## Contributing
 
 We welcome contributions! Find out how in our [contribution guide](CONTRIBUTING.md).

--- a/cics-bundle-deploy-reactor-archetype/pom.xml
+++ b/cics-bundle-deploy-reactor-archetype/pom.xml
@@ -4,7 +4,7 @@
   <parent>
   	<groupId>com.ibm.cics</groupId>
     <artifactId>cics-bundle-maven</artifactId>
-    <version>1.0.8-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>cics-bundle-deploy-reactor-archetype</artifactId>

--- a/cics-bundle-maven-plugin/pom.xml
+++ b/cics-bundle-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.ibm.cics</groupId>
     <artifactId>cics-bundle-maven</artifactId>
-    <version>1.0.8-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cics-bundle-maven-plugin</artifactId>

--- a/cics-bundle-maven-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/cics-bundle-maven-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -25,10 +25,8 @@
           <lifecycle>
             <id>default</id>
             <phases>
-              <compile>
-                com.ibm.cics:cics-bundle-maven-plugin:build
-              </compile>
               <package>
+                com.ibm.cics:cics-bundle-maven-plugin:build,
                 com.ibm.cics:cics-bundle-maven-plugin:package
               </package>
               <install>

--- a/cics-bundle-maven-site/pom.xml
+++ b/cics-bundle-maven-site/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.ibm.cics</groupId>
     <artifactId>cics-bundle-maven</artifactId>
-    <version>1.0.8-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>cics-bundle-maven-site</artifactId>
   <packaging>pom</packaging>

--- a/cics-bundle-reactor-archetype/pom.xml
+++ b/cics-bundle-reactor-archetype/pom.xml
@@ -4,7 +4,7 @@
   <parent>
   	<groupId>com.ibm.cics</groupId>
     <artifactId>cics-bundle-maven</artifactId>
-    <version>1.0.8-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>cics-bundle-reactor-archetype</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.ibm.cics</groupId>
   <artifactId>cics-bundle-maven</artifactId>
-  <version>1.0.8-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>CICS Bundle Maven Parent</name>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -2,12 +2,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>samples</artifactId>
-  <version>1.0.8-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <parent>
     <groupId>com.ibm.cics</groupId>
     <artifactId>cics-bundle-maven</artifactId>
-    <version>1.0.8-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   
   <dependencies>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.ibm.cics</groupId>
       <artifactId>cics-bundle-maven-plugin</artifactId>
-      <version>1.0.8-SNAPSHOT</version>
+      <version>2.0.0-SNAPSHOT</version>
     </dependency>
   </dependencies>
   


### PR DESCRIPTION
In Maven Bundle Plugin version 2.0.0 we moved the binding of the build goal from the compile phase to the package phase
https://github.com/IBM/cics-bundle-maven/issues/197