### PR TITLE
Update endpoints to migrate to Portal OSSRH Staging API

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ Snapshot builds are published to the Sonatype OSS Maven snapshots repository whi
     <pluginRepository>
       <id>sonatype-nexus-snapshots</id>
       <name>Sonatype Nexus Snapshots</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>

--- a/pom.xml
+++ b/pom.xml
@@ -30,12 +30,12 @@
     <snapshotRepository>
       <id>ossrh</id>
       <name>Sonatype Nexus Snapshots</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
     </snapshotRepository>
     <repository>
       <id>ossrh</id>
       <name>Nexus Release Repository</name>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+      <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/</url>
     </repository>
     <site>
       <id>github</id>
@@ -48,7 +48,7 @@
     <repository>
       <id>sonatype-nexus-snapshots</id>
       <name>Sonatype Nexus Snapshots</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>
@@ -171,7 +171,7 @@
           <version>1.6.8</version>
           <extensions>true</extensions>
           <configuration>
-            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+            <nexusUrl>https://ossrh-staging-api.central.sonatype.com/</nexusUrl>
             <serverId>ossrh</serverId>
             <stagingProfileId>2f4e6a35b09f57</stagingProfileId>
           </configuration>

--- a/samples/bundle-reactor-deploy/pom.xml
+++ b/samples/bundle-reactor-deploy/pom.xml
@@ -19,7 +19,7 @@
     <pluginRepository>
       <id>sonatype-nexus-snapshots</id>
       <name>Sonatype Nexus Snapshots</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>


### PR DESCRIPTION
This updates the endpoints to use the newer Portal OSSRH Staging API.

Because we're already using the Nexus deploy plugin, we don't need to do additional API calls, so this should be sufficient.

Once this is merged, the build _should_ fail with an authentication error. I'll then switch out the API key for one that works with the new publishing portal, and then re-run, at which point it should succeed.