### PR TITLE
Sonatype Portal requirements

### DIFF
--- a/cics-bundle-maven-plugin/pom.xml
+++ b/cics-bundle-maven-plugin/pom.xml
@@ -117,40 +117,48 @@
 
   <dependencyManagement>
     <dependencies>
+      <!-- These Maven-provided libraries don't need a version, but this is done to keep Sonatype Portal happy -->
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-model</artifactId>
         <scope>provided</scope>
+        <version>3.9.11</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-settings</artifactId>
         <scope>provided</scope>
+        <version>3.9.11</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-builder-support</artifactId>
         <scope>provided</scope>
+        <version>3.9.11</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-artifact</artifactId>
         <scope>provided</scope>
+        <version>3.9.11</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-plugin-api</artifactId>
         <scope>provided</scope>
+        <version>3.9.11</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-model-builder</artifactId>
         <scope>provided</scope>
+        <version>3.9.11</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-compat</artifactId>
         <scope>provided</scope>
+        <version>3.9.11</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/cics-bundle-maven-site/pom.xml
+++ b/cics-bundle-maven-site/pom.xml
@@ -8,6 +8,7 @@
   <artifactId>cics-bundle-maven-site</artifactId>
   <packaging>pom</packaging>
 
+  <name>CICS Bundle Maven Plugin site</name>
   <description>Supporting artifacts for the cics-bundle-maven-plugin.</description>
   <licenses>
     <license>

--- a/pom.xml
+++ b/pom.xml
@@ -7,8 +7,24 @@
   <packaging>pom</packaging>
 
   <name>CICS Bundle Maven Parent</name>
-
+  <url>https://github.com/IBM/cics-bundle-maven</url>
   <description>Supporting artifacts for the cics-bundle-maven-plugin.</description>
+
+  <scm>
+    <connection>scm:git:git://github.com/IBM/cics-bundle-maven.git</connection>
+    <developerConnection>scm:git:ssh://github.com:IBM/cics-bundle-maven.git</developerConnection>
+    <url>http://github.com/IBM/cics-bundle-maven/tree/master</url>
+  </scm>
+
+  <developers>
+    <developer>
+      <name>IBM</name>
+      <email>noreply@ibm.com</email>
+      <organization>IBM</organization>
+      <organizationUrl>https://www.ibm.com</organizationUrl>
+    </developer>
+  </developers>
+
   <licenses>
     <license>
       <name>EPL-2.0</name>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -9,7 +9,10 @@
     <artifactId>cics-bundle-maven</artifactId>
     <version>1.0.8</version>
   </parent>
-  
+
+  <name>CICS Bundle Maven Plugin samples</name>
+  <description>Samples that show how to use the CICS Bundle Maven Plugin</description>
+
   <dependencies>
     <!-- This will be installed from this build into the invoker's repo by invoker:install -->
     <dependency>


### PR DESCRIPTION
There are some POM changes that Sonatype Portal refuses to publish without. These include:

- `<url>`, `<scm>` and `<developers>`, which can be inherited from the parent.
- `<name>` per project.
- All dependencies need versions, even where they are provided by the environment.