### PR TITLE
Add Liberty server.xml and auth role support for WAR/EAR bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,133 @@ To create a CICS bundle in this way:
 1. To include CICS bundleparts like FILE or URIMAP, put the bundlepart files in your bundle Maven module's bundle parts directory, which defaults to `src/main/bundleParts`. Files in your Maven module's bundle parts directory will be included within the output CICS bundle, and supported types will have a `<define>` element added to the CICS bundle's `cics.xml`.
 The location of the bundle parts directory can be configured by using the `<bundlePartsDirectory>` property. The configured directory is relative to `src/main/`.
 
+### Configuring bundle part properties
+
+When building a CICS bundle with Java artifacts (WAR, EAR, OSGi bundle, or EBA), you can configure specific properties for each bundle part. This is done using the `<bundleParts>` configuration element.
+
+#### Common properties for all Java bundle parts
+
+All Java bundle parts support the `jvmserver` property, which specifies the name of the JVM server where the application will run:
+
+```xml
+<configuration>
+  <bundleParts>
+    <bundlePart implementation="com.ibm.cics.cbmp.Warbundle">
+      <artifact>
+        <artifactId>my-web-app</artifactId>
+      </artifact>
+      <jvmserver>MYJVMSRV</jvmserver>
+    </bundlePart>
+  </bundleParts>
+</configuration>
+```
+
+If you don't specify a `jvmserver` for a bundle part, it will use the `<defaultjvmserver>` value from the plugin configuration.
+
+#### WAR bundle part properties
+
+WAR bundle parts (`com.ibm.cics.cbmp.Warbundle`) support the following properties:
+
+- `jvmserver` - The name of the JVM server (defaults to `<defaultjvmserver>`)
+- `addCicsAllAuthenticatedRole` - Whether to add the CICS all-authenticated role (boolean, defaults to `true`)
+- `libertyAppConfigFile` - Path to a Liberty server.xml configuration file to include in the bundle (File, optional)
+
+Example with all properties:
+
+```xml
+<configuration>
+  <bundleParts>
+    <bundlePart implementation="com.ibm.cics.cbmp.Warbundle">
+      <artifact>
+        <artifactId>my-web-app</artifactId>
+      </artifact>
+      <jvmserver>DFHWLP</jvmserver>
+      <addCicsAllAuthenticatedRole>false</addCicsAllAuthenticatedRole>
+      <libertyAppConfigFile>server.xml</libertyAppConfigFile>
+    </bundlePart>
+  </bundleParts>
+</configuration>
+```
+
+The `libertyAppConfigFile` path is relative to the bundle module's base directory. The file will be included in the CICS bundle and referenced in the WAR bundle part definition.
+
+#### EAR bundle part properties
+
+EAR bundle parts (`com.ibm.cics.cbmp.Earbundle`) support the same properties as WAR bundle parts:
+
+- `jvmserver` - The name of the JVM server (defaults to `<defaultjvmserver>`)
+- `addCicsAllAuthenticatedRole` - Whether to add the CICS all-authenticated role (boolean, defaults to `true`)
+- `libertyAppConfigFile` - Path to a Liberty server.xml configuration file to include in the bundle (File, optional)
+
+Example:
+
+```xml
+<configuration>
+  <bundleParts>
+    <bundlePart implementation="com.ibm.cics.cbmp.Earbundle">
+      <artifact>
+        <artifactId>my-enterprise-app</artifactId>
+      </artifact>
+      <jvmserver>DFHWLP</jvmserver>
+      <addCicsAllAuthenticatedRole>false</addCicsAllAuthenticatedRole>
+      <libertyAppConfigFile>liberty-config/server.xml</libertyAppConfigFile>
+    </bundlePart>
+  </bundleParts>
+</configuration>
+```
+
+#### OSGi bundle part properties
+
+OSGi bundle parts (`com.ibm.cics.cbmp.Osgibundle`) support:
+
+- `jvmserver` - The name of the JVM server (defaults to `<defaultjvmserver>`)
+
+Example:
+
+```xml
+<configuration>
+  <bundleParts>
+    <bundlePart implementation="com.ibm.cics.cbmp.Osgibundle">
+      <artifact>
+        <artifactId>my-osgi-bundle</artifactId>
+      </artifact>
+      <jvmserver>DFHOSGI</jvmserver>
+    </bundlePart>
+  </bundleParts>
+</configuration>
+```
+
+#### Multiple bundle parts example
+
+You can configure multiple bundle parts in a single CICS bundle, each with their own properties:
+
+```xml
+<configuration>
+  <defaultjvmserver>DFHWLP</defaultjvmserver>
+  <bundleParts>
+    <bundlePart implementation="com.ibm.cics.cbmp.Warbundle">
+      <artifact>
+        <artifactId>frontend-app</artifactId>
+      </artifact>
+      <libertyAppConfigFile>frontend-server.xml</libertyAppConfigFile>
+    </bundlePart>
+    <bundlePart implementation="com.ibm.cics.cbmp.Warbundle">
+      <artifact>
+        <artifactId>backend-api</artifactId>
+      </artifact>
+      <jvmserver>APIJVM</jvmserver>
+      <addCicsAllAuthenticatedRole>false</addCicsAllAuthenticatedRole>
+    </bundlePart>
+    <bundlePart implementation="com.ibm.cics.cbmp.Osgibundle">
+      <artifact>
+        <artifactId>shared-services</artifactId>
+      </artifact>
+      <jvmserver>DFHOSGI</jvmserver>
+    </bundlePart>
+  </bundleParts>
+</configuration>
+```
+
 ## Create a CICS bundle (from an existing Java module) using `cics-bundle-maven-plugin`
 
 This way of building a CICS bundle modifies an existing Java module to make it also build the CICS bundle. This makes it more lightweight, but it has limitations - the CICS bundle can only contain one Java bundlepart, and can't contain any extra bundleparts such as FILE or URIMAP.

--- a/README.md
+++ b/README.md
@@ -319,6 +319,42 @@ To create a CICS bundle in this way:
 
   Now if you build the Java module with verify phase or later, i.e. `mvn clean verify` to avoid installing the artifact locally or `mvn clean install` to install it locally in your .m2 directory, it will build the module as usual but then also wrap it in a CICS bundle, and define it in the CICS bundle's manifest. The CICS bundle is added to the output of the module, by default using the `cics-bundle` classifier, and is ready to be stored in an artifact repository or deployed to CICS.
 
+### Configuring properties for bundle-war and bundle-ear goals
+
+When using the `bundle-war` or `bundle-ear` goals to package an existing Java module into a CICS bundle, you can configure additional properties beyond the required `jvmserver`. Both goals support the same configuration properties:
+
+- `jvmserver` - The name of the JVM server where the application will run (required)
+- `addCicsAllAuthenticatedRole` - Whether to add the CICS all-authenticated role (boolean, defaults to `true`)
+- `libertyAppConfigFile` - Path to a Liberty server.xml configuration file to include in the bundle (File, optional)
+
+Example configuration:
+
+```xml
+<build>
+  <plugins>
+    <plugin>
+      <groupId>com.ibm.cics</groupId>
+      <artifactId>cics-bundle-maven-plugin</artifactId>
+      <version>2.0.0</version>
+      <executions>
+        <execution>
+          <goals>
+            <goal>bundle-war</goal>
+          </goals>
+          <configuration>
+            <jvmserver>DFHWLP</jvmserver>
+            <addCicsAllAuthenticatedRole>false</addCicsAllAuthenticatedRole>
+            <libertyAppConfigFile>src/main/liberty/server.xml</libertyAppConfigFile>
+          </configuration>
+        </execution>
+      </executions>
+    </plugin>
+  </plugins>
+</build>
+```
+
+The `libertyAppConfigFile` path is relative to the module's base directory. The file will be included in the CICS bundle and referenced in the bundle part definition.
+
 ## Deploy a CICS bundle using `cics-bundle-maven-plugin`
 
 Following the instructions from one of the two methods above, you will have built a CICS bundle. You can use the `cics-bundle-maven-plugin` to install this into CICS by using the CICS bundle deployment API. This requires some setup in CICS as a [prerequisite](#prerequisites).

--- a/cics-bundle-maven-plugin/pom.xml
+++ b/cics-bundle-maven-plugin/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>com.ibm.cics</groupId>
       <artifactId>cics-bundle-common</artifactId>
-      <version>2.0.2</version>
+      <version>2.0.3-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.sonatype.plexus</groupId>
@@ -211,6 +211,10 @@
           <addTestClassPath>true</addTestClassPath>
           <goals>install</goals>
           <mergeUserSettings>true</mergeUserSettings>
+          <filterProperties>
+            <tycho-version>2.7.5</tycho-version>
+            <bnd-version>6.4.0</bnd-version>
+          </filterProperties>
           <scriptVariables>
             <wiremockPort>${wiremockPort}</wiremockPort>
             <pluginString>${project.groupId}:${project.artifactId}:${project.version}</pluginString>

--- a/cics-bundle-maven-plugin/src/it/setup-test-artifacts/pom.xml
+++ b/cics-bundle-maven-plugin/src/it/setup-test-artifacts/pom.xml
@@ -1,0 +1,52 @@
+<!--
+  #%L
+  CICS Bundle Maven Plugin
+  %%
+  Copyright (C) 2026 IBM Corp.
+  %%
+  This program and the accompanying materials are made
+  available under the terms of the Eclipse Public License 2.0
+  which is available at https://www.eclipse.org/legal/epl-2.0/
+  
+  SPDX-License-Identifier: EPL-2.0
+  #L%
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  
+  <groupId>com.ibm.cics</groupId>
+  <artifactId>setup-test-artifacts</artifactId>
+  <version>1.0.0</version>
+  <packaging>pom</packaging>
+  
+  <modules>
+    <module>test-war</module>
+    <module>test-ear</module>
+  </modules>
+  
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-ear-plugin</artifactId>
+          <version>3.0.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-war-plugin</artifactId>
+          <version>3.2.3</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.5.1</version>
+          <configuration>
+            <source>1.8</source>
+            <target>1.8</target>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+  
+</project>

--- a/cics-bundle-maven-plugin/src/it/setup-test-artifacts/test-ear/pom.xml
+++ b/cics-bundle-maven-plugin/src/it/setup-test-artifacts/test-ear/pom.xml
@@ -2,7 +2,7 @@
   #%L
   CICS Bundle Maven Plugin
   %%
-  Copyright (C) 2019 IBM Corp.
+  Copyright (C) 2026 IBM Corp.
   %%
   This program and the accompanying materials are made
   available under the terms of the Eclipse Public License 2.0
@@ -13,11 +13,14 @@
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.ibm.cics</groupId>
+    <artifactId>setup-test-artifacts</artifactId>
+    <version>1.0.0</version>
+  </parent>
  
-  <groupId>com.ibm.cics</groupId>
-  <artifactId>test-war</artifactId>
-  <version>1.0.0</version>
-  <packaging>war</packaging>
+  <artifactId>test-ear</artifactId>
+  <packaging>ear</packaging>
   
   <dependencies>
     <!-- provided -->
@@ -27,26 +30,24 @@
       <version>2.0</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>com.ibm.cics</groupId>
+      <artifactId>test-war</artifactId>
+      <version>1.0.0</version>      
+      <type>war</type>
+    </dependency>
   </dependencies>
   
   <build>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-war-plugin</artifactId>
-        <version>3.2.3</version>
+        <artifactId>maven-ear-plugin</artifactId>
+        <version>3.0.1</version>
         <configuration>
           <failOnMissingWebXml>false</failOnMissingWebXml>
           <packagingExcludes>pom.xml</packagingExcludes>
-          <warName>test-war</warName>
-        </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.5.1</version>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <earName>test-ear</earName>
         </configuration>
       </plugin>
     </plugins>

--- a/cics-bundle-maven-plugin/src/it/setup-test-artifacts/test-war/pom.xml
+++ b/cics-bundle-maven-plugin/src/it/setup-test-artifacts/test-war/pom.xml
@@ -14,17 +14,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.ibm.cics.test-reactor-osgi</groupId>
-    <artifactId>test-reactor-osgi</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <groupId>com.ibm.cics</groupId>
+    <artifactId>setup-test-artifacts</artifactId>
+    <version>1.0.0</version>
   </parent>
-  
-  <artifactId>test-tycho</artifactId>
-  <packaging>eclipse-plugin</packaging>
-  
-  <properties>
-    <tycho-version>@tycho-version@</tycho-version>
-  </properties>
+ 
+  <artifactId>test-war</artifactId>
+  <packaging>war</packaging>
   
   <dependencies>
     <!-- provided -->
@@ -35,14 +31,26 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
-
+  
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
-        <artifactId>tycho-maven-plugin</artifactId>
-        <version>${tycho-version}</version>
-        <extensions>true</extensions>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <version>3.2.3</version>
+        <configuration>
+          <failOnMissingWebXml>false</failOnMissingWebXml>
+          <packagingExcludes>pom.xml</packagingExcludes>
+          <warName>test-war</warName>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.5.1</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/cics-bundle-maven-plugin/src/it/test-bundle-ear-auth-role/pom.xml
+++ b/cics-bundle-maven-plugin/src/it/test-bundle-ear-auth-role/pom.xml
@@ -1,0 +1,63 @@
+<!--
+  #%L
+  CICS Bundle Maven Plugin
+  %%
+  Copyright (C) 2026 IBM Corp.
+  %%
+  This program and the accompanying materials are made
+  available under the terms of the Eclipse Public License 2.0
+  which is available at https://www.eclipse.org/legal/epl-2.0/
+  
+  SPDX-License-Identifier: EPL-2.0
+  #L%
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  
+  <groupId>com.ibm.cics.test-bundle-ear-auth-role</groupId>
+  <artifactId>test-bundle-ear-auth-role</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>ear</packaging>
+  
+  <dependencies>
+    <dependency>
+      <groupId>com.ibm.cics</groupId>
+      <artifactId>test-war</artifactId>
+      <version>1.0.0</version>      
+      <type>war</type>
+    </dependency>
+  </dependencies>
+  
+  <build>
+    <plugins>
+    
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-ear-plugin</artifactId>
+        <version>3.0.2</version>
+        <configuration>
+          <failOnMissingWebXml>false</failOnMissingWebXml>
+          <packagingExcludes>pom.xml</packagingExcludes>
+          <earName>test-ear-auth</earName>
+        </configuration>
+      </plugin>
+      
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>bundle-ear</goal>
+            </goals>
+            <configuration>
+              <jvmserver>DFHWLP</jvmserver>
+              <addCicsAllAuthenticatedRole>false</addCicsAllAuthenticatedRole>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/cics-bundle-maven-plugin/src/it/test-bundle-ear-auth-role/postbuild.bsh
+++ b/cics-bundle-maven-plugin/src/it/test-bundle-ear-auth-role/postbuild.bsh
@@ -1,0 +1,1 @@
+com.ibm.cics.cbmp.PostBuildTestBundleEarAuthRole.assertOutput(basedir);

--- a/cics-bundle-maven-plugin/src/it/test-bundle-ear-liberty-config/pom.xml
+++ b/cics-bundle-maven-plugin/src/it/test-bundle-ear-liberty-config/pom.xml
@@ -1,0 +1,63 @@
+<!--
+  #%L
+  CICS Bundle Maven Plugin
+  %%
+  Copyright (C) 2026 IBM Corp.
+  %%
+  This program and the accompanying materials are made
+  available under the terms of the Eclipse Public License 2.0
+  which is available at https://www.eclipse.org/legal/epl-2.0/
+  
+  SPDX-License-Identifier: EPL-2.0
+  #L%
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  
+  <groupId>com.ibm.cics.test-bundle-ear-liberty-config</groupId>
+  <artifactId>test-bundle-ear-liberty-config</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>ear</packaging>
+  
+  <dependencies>
+    <dependency>
+      <groupId>com.ibm.cics</groupId>
+      <artifactId>test-war</artifactId>
+      <version>1.0.0</version>      
+      <type>war</type>
+    </dependency>
+  </dependencies>
+  
+  <build>
+    <plugins>
+    
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-ear-plugin</artifactId>
+        <version>3.0.2</version>
+        <configuration>
+          <failOnMissingWebXml>false</failOnMissingWebXml>
+          <packagingExcludes>pom.xml</packagingExcludes>
+          <earName>test-ear-liberty</earName>
+        </configuration>
+      </plugin>
+      
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>bundle-ear</goal>
+            </goals>
+            <configuration>
+              <jvmserver>DFHWLP</jvmserver>
+              <libertyAppConfigFile>server.xml</libertyAppConfigFile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/cics-bundle-maven-plugin/src/it/test-bundle-ear-liberty-config/postbuild.bsh
+++ b/cics-bundle-maven-plugin/src/it/test-bundle-ear-liberty-config/postbuild.bsh
@@ -1,0 +1,1 @@
+com.ibm.cics.cbmp.PostBuildTestBundleEarLibertyConfig.assertOutput(basedir);

--- a/cics-bundle-maven-plugin/src/it/test-bundle-ear-liberty-config/server.xml
+++ b/cics-bundle-maven-plugin/src/it/test-bundle-ear-liberty-config/server.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+  <application>
+    <classloader delegation="parentLast"/>
+  </application>
+</server>

--- a/cics-bundle-maven-plugin/src/it/test-bundle-osgi-bundle-parts/pom.xml
+++ b/cics-bundle-maven-plugin/src/it/test-bundle-osgi-bundle-parts/pom.xml
@@ -22,7 +22,7 @@
   <packaging>eclipse-plugin</packaging>
 
   <properties>
-    <tycho-version>1.4.0</tycho-version>
+    <tycho-version>@tycho-version@</tycho-version>
   </properties>
 
   <dependencies>

--- a/cics-bundle-maven-plugin/src/it/test-bundle-osgi/pom.xml
+++ b/cics-bundle-maven-plugin/src/it/test-bundle-osgi/pom.xml
@@ -22,7 +22,7 @@
   <packaging>eclipse-plugin</packaging>
 
   <properties>
-    <tycho-version>1.4.0</tycho-version>
+    <tycho-version>@tycho-version@</tycho-version>
   </properties>
 
   <dependencies>

--- a/cics-bundle-maven-plugin/src/it/test-bundle-war-auth-role/pom.xml
+++ b/cics-bundle-maven-plugin/src/it/test-bundle-war-auth-role/pom.xml
@@ -1,0 +1,71 @@
+<!--
+  #%L
+  CICS Bundle Maven Plugin
+  %%
+  Copyright (C) 2026 IBM Corp.
+  %%
+  This program and the accompanying materials are made
+  available under the terms of the Eclipse Public License 2.0
+  which is available at https://www.eclipse.org/legal/epl-2.0/
+  
+  SPDX-License-Identifier: EPL-2.0
+  #L%
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.ibm.cics.test-bundle-war-auth-role</groupId>
+  <artifactId>test-bundle-war-auth-role</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>war</packaging>
+  
+  <dependencies>
+    <dependency>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>javax.ws.rs-api</artifactId>
+      <version>2.0</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <version>3.2.3</version>
+        <configuration>
+          <failOnMissingWebXml>false</failOnMissingWebXml>
+          <packagingExcludes>pom.xml</packagingExcludes>
+          <warName>test-war-auth</warName>
+        </configuration>
+      </plugin>
+      
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.5.1</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+      
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>bundle-war</goal>
+            </goals>
+            <configuration>
+              <jvmserver>DFHWLP</jvmserver>
+              <addCicsAllAuthenticatedRole>false</addCicsAllAuthenticatedRole>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  
+</project>

--- a/cics-bundle-maven-plugin/src/it/test-bundle-war-auth-role/postbuild.bsh
+++ b/cics-bundle-maven-plugin/src/it/test-bundle-war-auth-role/postbuild.bsh
@@ -1,0 +1,1 @@
+com.ibm.cics.cbmp.PostBuildTestBundleWarAuthRole.assertOutput(basedir);

--- a/cics-bundle-maven-plugin/src/it/test-bundle-war-auth-role/src/main/java/test_war/TestEndpoint.java
+++ b/cics-bundle-maven-plugin/src/it/test-bundle-war-auth-role/src/main/java/test_war/TestEndpoint.java
@@ -1,0 +1,12 @@
+package test_war;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("/")
+public class TestEndpoint {
+	@GET
+	public String get() {
+		return "test";
+	}
+}

--- a/cics-bundle-maven-plugin/src/it/test-bundle-war-liberty-config/pom.xml
+++ b/cics-bundle-maven-plugin/src/it/test-bundle-war-liberty-config/pom.xml
@@ -1,0 +1,72 @@
+<!--
+  #%L
+  CICS Bundle Maven Plugin
+  %%
+  Copyright (C) 2026 IBM Corp.
+  %%
+  This program and the accompanying materials are made
+  available under the terms of the Eclipse Public License 2.0
+  which is available at https://www.eclipse.org/legal/epl-2.0/
+  
+  SPDX-License-Identifier: EPL-2.0
+  #L%
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.ibm.cics.test-bundle-war-liberty-config</groupId>
+  <artifactId>test-bundle-war-liberty-config</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>war</packaging>
+  
+  <dependencies>
+    <!-- provided -->
+    <dependency>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>javax.ws.rs-api</artifactId>
+      <version>2.0</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <version>3.2.3</version>
+        <configuration>
+          <failOnMissingWebXml>false</failOnMissingWebXml>
+          <packagingExcludes>pom.xml</packagingExcludes>
+          <warName>test-war-liberty</warName>
+        </configuration>
+      </plugin>
+      
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.5.1</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+      
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>bundle-war</goal>
+            </goals>
+            <configuration>
+              <jvmserver>DFHWLP</jvmserver>
+              <libertyAppConfigFile>server.xml</libertyAppConfigFile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  
+</project>

--- a/cics-bundle-maven-plugin/src/it/test-bundle-war-liberty-config/postbuild.bsh
+++ b/cics-bundle-maven-plugin/src/it/test-bundle-war-liberty-config/postbuild.bsh
@@ -1,0 +1,1 @@
+com.ibm.cics.cbmp.PostBuildTestBundleWarLibertyConfig.assertOutput(basedir);

--- a/cics-bundle-maven-plugin/src/it/test-bundle-war-liberty-config/server.xml
+++ b/cics-bundle-maven-plugin/src/it/test-bundle-war-liberty-config/server.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+  <application>
+    <classloader delegation="parentLast"/>
+  </application>
+</server>

--- a/cics-bundle-maven-plugin/src/it/test-bundle-war-liberty-config/src/main/java/test_war/TestEndpoint.java
+++ b/cics-bundle-maven-plugin/src/it/test-bundle-war-liberty-config/src/main/java/test_war/TestEndpoint.java
@@ -1,0 +1,12 @@
+package test_war;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("/")
+public class TestEndpoint {
+	@GET
+	public String get() {
+		return "test";
+	}
+}

--- a/cics-bundle-maven-plugin/src/it/test-reactor-ear-auth-role/pom.xml
+++ b/cics-bundle-maven-plugin/src/it/test-reactor-ear-auth-role/pom.xml
@@ -1,0 +1,53 @@
+<!--
+  #%L
+  CICS Bundle Maven Plugin
+  %%
+  Copyright (C) 2026 IBM Corp.
+  %%
+  This program and the accompanying materials are made
+  available under the terms of the Eclipse Public License 2.0
+  which is available at https://www.eclipse.org/legal/epl-2.0/
+  
+  SPDX-License-Identifier: EPL-2.0
+  #L%
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  
+  <groupId>test-reactor-ear-auth-role</groupId>
+  <artifactId>test-bundle</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>cics-bundle</packaging>
+  
+  <dependencies>
+    <dependency>
+      <groupId>com.ibm.cics</groupId>
+      <artifactId>test-ear</artifactId>
+      <version>1.0.0</version>
+      <type>ear</type>
+    </dependency>
+  </dependencies>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <extensions>true</extensions>
+        <configuration>
+          <bundleParts>
+            <bundlePart implementation="com.ibm.cics.cbmp.Earbundle">
+              <artifact>
+                <artifactId>test-ear</artifactId>
+              </artifact>
+              <jvmserver>EYUCMCIJ</jvmserver>
+              <addCicsAllAuthenticatedRole>false</addCicsAllAuthenticatedRole>
+            </bundlePart>
+          </bundleParts>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  
+</project>

--- a/cics-bundle-maven-plugin/src/it/test-reactor-ear-auth-role/postbuild.bsh
+++ b/cics-bundle-maven-plugin/src/it/test-reactor-ear-auth-role/postbuild.bsh
@@ -1,0 +1,1 @@
+com.ibm.cics.cbmp.PostBuildEarAuthRole.assertOutput(basedir);

--- a/cics-bundle-maven-plugin/src/it/test-reactor-ear-liberty-config/pom.xml
+++ b/cics-bundle-maven-plugin/src/it/test-reactor-ear-liberty-config/pom.xml
@@ -1,0 +1,53 @@
+<!--
+  #%L
+  CICS Bundle Maven Plugin
+  %%
+  Copyright (C) 2026 IBM Corp.
+  %%
+  This program and the accompanying materials are made
+  available under the terms of the Eclipse Public License 2.0
+  which is available at https://www.eclipse.org/legal/epl-2.0/
+  
+  SPDX-License-Identifier: EPL-2.0
+  #L%
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  
+  <groupId>test-reactor-ear-liberty-config</groupId>
+  <artifactId>test-bundle</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>cics-bundle</packaging>
+  
+  <dependencies>
+    <dependency>
+      <groupId>com.ibm.cics</groupId>
+      <artifactId>test-ear</artifactId>
+      <version>1.0.0</version>
+      <type>ear</type>
+    </dependency>
+  </dependencies>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <extensions>true</extensions>
+        <configuration>
+          <bundleParts>
+            <bundlePart implementation="com.ibm.cics.cbmp.Earbundle">
+              <artifact>
+                <artifactId>test-ear</artifactId>
+              </artifact>
+              <jvmserver>EYUCMCIJ</jvmserver>
+              <libertyAppConfigFile>${project.basedir}/server.xml</libertyAppConfigFile>
+            </bundlePart>
+          </bundleParts>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  
+</project>

--- a/cics-bundle-maven-plugin/src/it/test-reactor-ear-liberty-config/postbuild.bsh
+++ b/cics-bundle-maven-plugin/src/it/test-reactor-ear-liberty-config/postbuild.bsh
@@ -1,0 +1,1 @@
+com.ibm.cics.cbmp.PostBuildEarLibertyConfig.assertOutput(basedir);

--- a/cics-bundle-maven-plugin/src/it/test-reactor-ear-liberty-config/server.xml
+++ b/cics-bundle-maven-plugin/src/it/test-reactor-ear-liberty-config/server.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<application id="test-ear" name="test-ear" type="ear" location="test-ear-1.0.0.ear">
+    <application-bnd>
+        <security-role name="Administrator">
+            <user name="admin" />
+        </security-role>
+    </application-bnd>
+</application>

--- a/cics-bundle-maven-plugin/src/it/test-reactor-ear-liberty-full/pom.xml
+++ b/cics-bundle-maven-plugin/src/it/test-reactor-ear-liberty-full/pom.xml
@@ -1,0 +1,54 @@
+<!--
+  #%L
+  CICS Bundle Maven Plugin
+  %%
+  Copyright (C) 2026 IBM Corp.
+  %%
+  This program and the accompanying materials are made
+  available under the terms of the Eclipse Public License 2.0
+  which is available at https://www.eclipse.org/legal/epl-2.0/
+  
+  SPDX-License-Identifier: EPL-2.0
+  #L%
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  
+  <groupId>test-reactor-ear-liberty-full</groupId>
+  <artifactId>test-bundle</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>cics-bundle</packaging>
+  
+  <dependencies>
+    <dependency>
+      <groupId>com.ibm.cics</groupId>
+      <artifactId>test-ear</artifactId>
+      <version>1.0.0</version>
+      <type>ear</type>
+    </dependency>
+  </dependencies>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <extensions>true</extensions>
+        <configuration>
+          <bundleParts>
+            <bundlePart implementation="com.ibm.cics.cbmp.Earbundle">
+              <artifact>
+                <artifactId>test-ear</artifactId>
+              </artifact>
+              <jvmserver>EYUCMCIJ</jvmserver>
+              <addCicsAllAuthenticatedRole>false</addCicsAllAuthenticatedRole>
+              <libertyAppConfigFile>${project.basedir}/server.xml</libertyAppConfigFile>
+            </bundlePart>
+          </bundleParts>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  
+</project>

--- a/cics-bundle-maven-plugin/src/it/test-reactor-ear-liberty-full/postbuild.bsh
+++ b/cics-bundle-maven-plugin/src/it/test-reactor-ear-liberty-full/postbuild.bsh
@@ -1,0 +1,1 @@
+com.ibm.cics.cbmp.PostBuildEarLibertyFull.assertOutput(basedir);

--- a/cics-bundle-maven-plugin/src/it/test-reactor-ear-liberty-full/server.xml
+++ b/cics-bundle-maven-plugin/src/it/test-reactor-ear-liberty-full/server.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<application id="test-ear" name="test-ear" type="ear" location="test-ear-1.0.0.ear">
+    <application-bnd>
+        <security-role name="Administrator">
+            <user name="admin" />
+        </security-role>
+    </application-bnd>
+</application>

--- a/cics-bundle-maven-plugin/src/it/test-reactor-eba/test-osgi/pom.xml
+++ b/cics-bundle-maven-plugin/src/it/test-reactor-eba/test-osgi/pom.xml
@@ -37,7 +37,7 @@
       <plugin>
         <groupId>biz.aQute.bnd</groupId>
         <artifactId>bnd-maven-plugin</artifactId>
-        <version>4.2.0</version>
+        <version>@bnd-version@</version>
         <executions>
           <execution>
             <goals>

--- a/cics-bundle-maven-plugin/src/it/test-reactor-osgi-jvmserver/test-osgi/pom.xml
+++ b/cics-bundle-maven-plugin/src/it/test-reactor-osgi-jvmserver/test-osgi/pom.xml
@@ -37,7 +37,7 @@
       <plugin>
         <groupId>biz.aQute.bnd</groupId>
         <artifactId>bnd-maven-plugin</artifactId>
-        <version>4.2.0</version>
+        <version>@bnd-version@</version>
         <executions>
           <execution>
             <goals>

--- a/cics-bundle-maven-plugin/src/it/test-reactor-osgi-jvmserver/test-tycho/pom.xml
+++ b/cics-bundle-maven-plugin/src/it/test-reactor-osgi-jvmserver/test-tycho/pom.xml
@@ -23,7 +23,7 @@
   <packaging>eclipse-plugin</packaging>
   
   <properties>
-    <tycho-version>1.4.0</tycho-version>
+    <tycho-version>@tycho-version@</tycho-version>
   </properties>
   
   <dependencies>

--- a/cics-bundle-maven-plugin/src/it/test-reactor-osgi-no-defaultjvmserver/test-osgi/pom.xml
+++ b/cics-bundle-maven-plugin/src/it/test-reactor-osgi-no-defaultjvmserver/test-osgi/pom.xml
@@ -37,7 +37,7 @@
       <plugin>
         <groupId>biz.aQute.bnd</groupId>
         <artifactId>bnd-maven-plugin</artifactId>
-        <version>4.2.0</version>
+        <version>@bnd-version@</version>
         <executions>
           <execution>
             <goals>

--- a/cics-bundle-maven-plugin/src/it/test-reactor-osgi/test-osgi/pom.xml
+++ b/cics-bundle-maven-plugin/src/it/test-reactor-osgi/test-osgi/pom.xml
@@ -37,7 +37,7 @@
       <plugin>
         <groupId>biz.aQute.bnd</groupId>
         <artifactId>bnd-maven-plugin</artifactId>
-        <version>4.2.0</version>
+        <version>@bnd-version@</version>
         <executions>
           <execution>
             <goals>

--- a/cics-bundle-maven-plugin/src/it/test-reactor-war-auth-role/pom.xml
+++ b/cics-bundle-maven-plugin/src/it/test-reactor-war-auth-role/pom.xml
@@ -1,0 +1,53 @@
+<!--
+  #%L
+  CICS Bundle Maven Plugin
+  %%
+  Copyright (C) 2026 IBM Corp.
+  %%
+  This program and the accompanying materials are made
+  available under the terms of the Eclipse Public License 2.0
+  which is available at https://www.eclipse.org/legal/epl-2.0/
+  
+  SPDX-License-Identifier: EPL-2.0
+  #L%
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  
+  <groupId>test-reactor-war-auth-role</groupId>
+  <artifactId>test-bundle</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>cics-bundle</packaging>
+  
+  <dependencies>
+    <dependency>
+      <groupId>com.ibm.cics</groupId>
+      <artifactId>test-war</artifactId>
+      <version>1.0.0</version>
+      <type>war</type>
+    </dependency>
+  </dependencies>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <extensions>true</extensions>
+        <configuration>
+          <bundleParts>
+            <bundlePart implementation="com.ibm.cics.cbmp.Warbundle">
+              <artifact>
+                <artifactId>test-war</artifactId>
+              </artifact>
+              <jvmserver>EYUCMCIJ</jvmserver>
+              <addCicsAllAuthenticatedRole>false</addCicsAllAuthenticatedRole>
+            </bundlePart>
+          </bundleParts>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  
+</project>

--- a/cics-bundle-maven-plugin/src/it/test-reactor-war-auth-role/postbuild.bsh
+++ b/cics-bundle-maven-plugin/src/it/test-reactor-war-auth-role/postbuild.bsh
@@ -1,0 +1,1 @@
+com.ibm.cics.cbmp.PostBuildWarAuthRole.assertOutput(basedir);

--- a/cics-bundle-maven-plugin/src/it/test-reactor-war-liberty-config/pom.xml
+++ b/cics-bundle-maven-plugin/src/it/test-reactor-war-liberty-config/pom.xml
@@ -1,0 +1,53 @@
+<!--
+  #%L
+  CICS Bundle Maven Plugin
+  %%
+  Copyright (C) 2026 IBM Corp.
+  %%
+  This program and the accompanying materials are made
+  available under the terms of the Eclipse Public License 2.0
+  which is available at https://www.eclipse.org/legal/epl-2.0/
+  
+  SPDX-License-Identifier: EPL-2.0
+  #L%
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  
+  <groupId>test-reactor-war-liberty-config</groupId>
+  <artifactId>test-bundle</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>cics-bundle</packaging>
+  
+  <dependencies>
+    <dependency>
+      <groupId>com.ibm.cics</groupId>
+      <artifactId>test-war</artifactId>
+      <version>1.0.0</version>
+      <type>war</type>
+    </dependency>
+  </dependencies>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <extensions>true</extensions>
+        <configuration>
+          <bundleParts>
+            <bundlePart implementation="com.ibm.cics.cbmp.Warbundle">
+              <artifact>
+                <artifactId>test-war</artifactId>
+              </artifact>
+              <jvmserver>EYUCMCIJ</jvmserver>
+              <libertyAppConfigFile>${project.basedir}/server.xml</libertyAppConfigFile>
+            </bundlePart>
+          </bundleParts>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  
+</project>

--- a/cics-bundle-maven-plugin/src/it/test-reactor-war-liberty-config/postbuild.bsh
+++ b/cics-bundle-maven-plugin/src/it/test-reactor-war-liberty-config/postbuild.bsh
@@ -1,0 +1,1 @@
+com.ibm.cics.cbmp.PostBuildWarLibertyConfig.assertOutput(basedir);

--- a/cics-bundle-maven-plugin/src/it/test-reactor-war-liberty-config/server.xml
+++ b/cics-bundle-maven-plugin/src/it/test-reactor-war-liberty-config/server.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<application id="test-war" name="test-war" type="war" location="test-war-1.0.0.war">
+    <application-bnd>
+        <security-role name="Administrator">
+            <user name="admin" />
+        </security-role>
+    </application-bnd>
+</application>

--- a/cics-bundle-maven-plugin/src/it/test-reactor-war-liberty-full/pom.xml
+++ b/cics-bundle-maven-plugin/src/it/test-reactor-war-liberty-full/pom.xml
@@ -1,0 +1,54 @@
+<!--
+  #%L
+  CICS Bundle Maven Plugin
+  %%
+  Copyright (C) 2026 IBM Corp.
+  %%
+  This program and the accompanying materials are made
+  available under the terms of the Eclipse Public License 2.0
+  which is available at https://www.eclipse.org/legal/epl-2.0/
+  
+  SPDX-License-Identifier: EPL-2.0
+  #L%
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  
+  <groupId>test-reactor-war-liberty-full</groupId>
+  <artifactId>test-bundle</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>cics-bundle</packaging>
+  
+  <dependencies>
+    <dependency>
+      <groupId>com.ibm.cics</groupId>
+      <artifactId>test-war</artifactId>
+      <version>1.0.0</version>
+      <type>war</type>
+    </dependency>
+  </dependencies>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <extensions>true</extensions>
+        <configuration>
+          <bundleParts>
+            <bundlePart implementation="com.ibm.cics.cbmp.Warbundle">
+              <artifact>
+                <artifactId>test-war</artifactId>
+              </artifact>
+              <jvmserver>EYUCMCIJ</jvmserver>
+              <addCicsAllAuthenticatedRole>false</addCicsAllAuthenticatedRole>
+              <libertyAppConfigFile>${project.basedir}/server.xml</libertyAppConfigFile>
+            </bundlePart>
+          </bundleParts>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  
+</project>

--- a/cics-bundle-maven-plugin/src/it/test-reactor-war-liberty-full/postbuild.bsh
+++ b/cics-bundle-maven-plugin/src/it/test-reactor-war-liberty-full/postbuild.bsh
@@ -1,0 +1,1 @@
+com.ibm.cics.cbmp.PostBuildWarLibertyFull.assertOutput(basedir);

--- a/cics-bundle-maven-plugin/src/it/test-reactor-war-liberty-full/server.xml
+++ b/cics-bundle-maven-plugin/src/it/test-reactor-war-liberty-full/server.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<application id="test-war" name="test-war" type="war" location="test-war-1.0.0.war">
+    <application-bnd>
+        <security-role name="Administrator">
+            <user name="admin" />
+        </security-role>
+    </application-bnd>
+</application>

--- a/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/AbstractBundleWebAppMojo.java
+++ b/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/AbstractBundleWebAppMojo.java
@@ -1,0 +1,78 @@
+package com.ibm.cics.cbmp;
+
+/*-
+ * #%L
+ * CICS Bundle Maven Plugin
+ * %%
+ * Copyright (C) 2026 IBM Corp.
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import java.io.File;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Parameter;
+
+import com.ibm.cics.bundle.parts.BundlePublisher.PublishException;
+
+/**
+ * Abstract base class for bundle mojos that support Liberty web applications (WAR and EAR).
+ * Adds support for Liberty-specific configuration properties.
+ */
+public abstract class AbstractBundleWebAppMojo extends AbstractBundleJavaMojo {
+
+	/**
+	 * Whether to add the <code>cicsAllAuthenticated</code> role to the application.
+	 * Defaults to true.
+	 */
+	@Parameter(property = "cicsbundle.addCicsAllAuthenticatedRole", defaultValue = "true")
+	protected boolean addCicsAllAuthenticatedRole;
+
+	/**
+	 * Path to a Liberty server.xml snippet containing a single <code>>application<</code> element
+     * to add to the application when defined to Liberty.
+	 * The path is relative to the project base directory.
+	 */
+	@Parameter(property = "cicsbundle.libertyAppConfigFile")
+	protected File libertyAppConfigFile;
+
+	@Override
+	public void execute() throws MojoExecutionException, MojoFailureException {
+		// Validate libertyAppConfigFile if specified
+		if (libertyAppConfigFile != null && !libertyAppConfigFile.exists()) {
+			throw new MojoExecutionException("Liberty app config file does not exist: " + libertyAppConfigFile);
+		}
+
+		// Call parent execute which will call getBundlePartBinding()
+		super.execute();
+	}
+
+	/**
+	 * Configure the bundle part binding with Liberty-specific properties.
+	 * Subclasses must implement this to return the appropriate binding type.
+	 */
+	@Override
+	protected abstract AbstractJavaBundlePartBinding getBundlePartBinding();
+
+	/**
+	 * Get the configured value for addCicsAllAuthenticatedRole.
+	 */
+	protected boolean isAddCicsAllAuthenticatedRole() {
+		return addCicsAllAuthenticatedRole;
+	}
+
+	/**
+	 * Get the configured Liberty app config file.
+	 */
+	protected File getLibertyAppConfigFile() {
+		return libertyAppConfigFile;
+	}
+
+}

--- a/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/BundleEarMojo.java
+++ b/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/BundleEarMojo.java
@@ -9,7 +9,7 @@ package com.ibm.cics.cbmp;
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  * #L%
  */
@@ -23,11 +23,14 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
  * <p>Use this mojo to add configuration to an existing EAR project so that it is packaged as a CICS bundle, without creating an additional Maven module.</p>
  */
 @Mojo(name = "bundle-ear", requiresDependencyResolution = ResolutionScope.TEST, defaultPhase = LifecyclePhase.VERIFY)
-public class BundleEarMojo extends AbstractBundleJavaMojo {
+public class BundleEarMojo extends AbstractBundleWebAppMojo {
 	
 	@Override
 	protected AbstractJavaBundlePartBinding getBundlePartBinding() {
-		return new Earbundle();
+		Earbundle earbundle = new Earbundle();
+		earbundle.setAddCicsAllAuthenticatedRole(isAddCicsAllAuthenticatedRole());
+		earbundle.setLibertyAppConfigFile(getLibertyAppConfigFile());
+		return earbundle;
 	}
 
 }

--- a/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/BundleWarMojo.java
+++ b/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/BundleWarMojo.java
@@ -9,7 +9,7 @@ package com.ibm.cics.cbmp;
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  * #L%
  */
@@ -23,11 +23,14 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
  * <p>Use this mojo to add configuration to an existing WAR project so that it is packaged as a CICS bundle, without creating an additional Maven module.</p>
  */
 @Mojo(name = "bundle-war", requiresDependencyResolution = ResolutionScope.TEST, defaultPhase = LifecyclePhase.VERIFY)
-public class BundleWarMojo extends AbstractBundleJavaMojo {
+public class BundleWarMojo extends AbstractBundleWebAppMojo {
 	
 	@Override
 	protected AbstractJavaBundlePartBinding getBundlePartBinding() {
-		return new Warbundle();
+		Warbundle warbundle = new Warbundle();
+		warbundle.setAddCicsAllAuthenticatedRole(isAddCicsAllAuthenticatedRole());
+		warbundle.setLibertyAppConfigFile(getLibertyAppConfigFile());
+		return warbundle;
 	}
 
 }

--- a/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/Earbundle.java
+++ b/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/Earbundle.java
@@ -1,5 +1,7 @@
 package com.ibm.cics.cbmp;
 
+import java.io.File;
+
 import org.apache.maven.plugin.MojoExecutionException;
 
 import com.ibm.cics.bundle.parts.EarBundlePart;
@@ -13,18 +15,39 @@ import com.ibm.cics.bundle.parts.EarBundlePart;
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  * #L%
  */
 
 public class Earbundle extends AbstractJavaBundlePartBinding {
 	
+	protected boolean addCicsAllAuthenticatedRole = true;
+	protected File libertyAppConfigFile;
+	
+	public boolean getAddCicsAllAuthenticatedRole() {
+		return addCicsAllAuthenticatedRole;
+	}
+	
+	public void setAddCicsAllAuthenticatedRole(boolean addCicsAllAuthenticatedRole) {
+		this.addCicsAllAuthenticatedRole = addCicsAllAuthenticatedRole;
+	}
+	
+	public File getLibertyAppConfigFile() {
+		return libertyAppConfigFile;
+	}
+	
+	public void setLibertyAppConfigFile(File libertyAppConfigFile) {
+		this.libertyAppConfigFile = libertyAppConfigFile;
+	}
+	
 	@Override
 	public EarBundlePart toBundlePartImpl() throws MojoExecutionException {
 		return new EarBundlePart(
 			getName(),
 			getJvmserver(),
+			addCicsAllAuthenticatedRole,
+			libertyAppConfigFile,
 			resolvedArtifact.getFile()
 		);
 	}

--- a/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/Warbundle.java
+++ b/cics-bundle-maven-plugin/src/main/java/com/ibm/cics/cbmp/Warbundle.java
@@ -1,5 +1,7 @@
 package com.ibm.cics.cbmp;
 
+import java.io.File;
+
 import org.apache.maven.plugin.MojoExecutionException;
 
 import com.ibm.cics.bundle.parts.WarBundlePart;
@@ -13,18 +15,39 @@ import com.ibm.cics.bundle.parts.WarBundlePart;
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  * #L%
  */
 
 public class Warbundle extends AbstractJavaBundlePartBinding {
 
+	protected boolean addCicsAllAuthenticatedRole = true;
+	protected File libertyAppConfigFile;
+	
+	public boolean getAddCicsAllAuthenticatedRole() {
+		return addCicsAllAuthenticatedRole;
+	}
+	
+	public void setAddCicsAllAuthenticatedRole(boolean addCicsAllAuthenticatedRole) {
+		this.addCicsAllAuthenticatedRole = addCicsAllAuthenticatedRole;
+	}
+	
+	public File getLibertyAppConfigFile() {
+		return libertyAppConfigFile;
+	}
+	
+	public void setLibertyAppConfigFile(File libertyAppConfigFile) {
+		this.libertyAppConfigFile = libertyAppConfigFile;
+	}
+
 	@Override
 	public WarBundlePart toBundlePartImpl() throws MojoExecutionException {
 		return new WarBundlePart(
 			getName(),
 			getJvmserver(),
+			addCicsAllAuthenticatedRole,
+			libertyAppConfigFile,
 			resolvedArtifact.getFile()
 		);
 	}

--- a/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/EarbundleTest.java
+++ b/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/EarbundleTest.java
@@ -9,10 +9,16 @@ package com.ibm.cics.cbmp;
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  * #L%
  */
+
+import org.junit.Test;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
 
 public class EarbundleTest extends AbstractJavaBundlePartBindingTestCase {
 
@@ -24,6 +30,40 @@ public class EarbundleTest extends AbstractJavaBundlePartBindingTestCase {
 	@Override
 	protected String getRootElementName() {
 		return "earbundle";
+	}
+
+	@Test
+	public void addCicsAllAuthenticatedRoleFalse() throws Exception {
+		((Earbundle) binding).setAddCicsAllAuthenticatedRole(false);
+		Map<String, String> attrs = new HashMap<>();
+		attrs.put("addCICSAllAuth", "false");
+		setOtherExpectedAttributes(attrs);
+		
+		assertBundleResources();
+	}
+
+	@Test
+	public void libertyAppConfigFile() throws Exception {
+		File configFile = new File("server.xml");
+		((Earbundle) binding).setLibertyAppConfigFile(configFile);
+		Map<String, String> attrs = new HashMap<>();
+		attrs.put("appConfigFile", "server.xml");
+		setOtherExpectedAttributes(attrs);
+		
+		assertBundleResources();
+	}
+
+	@Test
+	public void bothNewProperties() throws Exception {
+		((Earbundle) binding).setAddCicsAllAuthenticatedRole(false);
+		File configFile = new File("server.xml");
+		((Earbundle) binding).setLibertyAppConfigFile(configFile);
+		Map<String, String> attrs = new HashMap<>();
+		attrs.put("addCICSAllAuth", "false");
+		attrs.put("appConfigFile", "server.xml");
+		setOtherExpectedAttributes(attrs);
+		
+		assertBundleResources();
 	}
 
 }

--- a/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildEarAuthRole.java
+++ b/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildEarAuthRole.java
@@ -1,0 +1,63 @@
+package com.ibm.cics.cbmp;
+/*-
+ * #%L
+ * CICS Bundle Maven Plugin
+ * %%
+ * Copyright (C) 2026 IBM Corp.
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static com.ibm.cics.cbmp.BundleValidator.assertBundleContents;
+import static com.ibm.cics.cbmp.BundleValidator.bfv;
+import static com.ibm.cics.cbmp.BundleValidator.manifestValidator;
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import org.xmlunit.matchers.CompareMatcher;
+
+public class PostBuildEarAuthRole {
+
+	private static final String BASE_NAME = "/test-ear-1.0.0";
+	private static final String EAR_BUNDLE_PART = BASE_NAME + ".earbundle";
+	private static final String EAR_BUNDLE = BASE_NAME + ".ear";
+
+	public static void assertOutput(File root) throws Exception {
+		Path cicsBundle = root.toPath().resolve("target/test-bundle-0.0.1-SNAPSHOT.zip");
+		
+		assertBundleContents(
+				cicsBundle,
+				manifestValidator(
+					"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" + 
+					"<manifest xmlns=\"http://www.ibm.com/xmlns/prod/cics/bundle\" bundleMajorVer=\"0\" bundleMicroVer=\"1\" bundleMinorVer=\"0\" bundleRelease=\"0\" bundleVersion=\"1\" id=\"test-bundle\">\n" +
+					"  <meta_directives>\n" +
+					"    <timestamp>2019-09-11T21:12:17.023Z</timestamp>\n" +
+					"  </meta_directives>\n" +
+					"  <define name=\"test-ear-1.0.0\" path=\"test-ear-1.0.0.earbundle\" type=\"http://www.ibm.com/xmlns/prod/cics/bundle/EARBUNDLE\"/>\n" +
+					"</manifest>"
+				),
+				bfv(
+					EAR_BUNDLE_PART,
+					is -> assertThat(
+						is,
+						CompareMatcher.isIdenticalTo(
+							"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + 
+							"<earbundle addCICSAllAuth=\"false\" jvmserver=\"EYUCMCIJ\" symbolicname=\"test-ear-1.0.0\"/>"
+						)
+					)
+				),
+				bfv(
+					EAR_BUNDLE,
+					is -> {}
+				)
+			);
+	}
+	
+}

--- a/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildEarLibertyConfig.java
+++ b/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildEarLibertyConfig.java
@@ -1,0 +1,80 @@
+package com.ibm.cics.cbmp;
+/*-
+ * #%L
+ * CICS Bundle Maven Plugin
+ * %%
+ * Copyright (C) 2026 IBM Corp.
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static com.ibm.cics.cbmp.BundleValidator.assertBundleContents;
+import static com.ibm.cics.cbmp.BundleValidator.bfv;
+import static com.ibm.cics.cbmp.BundleValidator.manifestValidator;
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import org.xmlunit.matchers.CompareMatcher;
+
+public class PostBuildEarLibertyConfig {
+
+	private static final String BASE_NAME = "/test-ear-1.0.0";
+	private static final String EAR_BUNDLE_PART = BASE_NAME + ".earbundle";
+	private static final String EAR_BUNDLE = BASE_NAME + ".ear";
+	private static final String SERVER_XML = "/server.xml";
+
+	public static void assertOutput(File root) throws Exception {
+		Path cicsBundle = root.toPath().resolve("target/test-bundle-0.0.1-SNAPSHOT.zip");
+		
+		assertBundleContents(
+				cicsBundle,
+				manifestValidator(
+					"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" + 
+					"<manifest xmlns=\"http://www.ibm.com/xmlns/prod/cics/bundle\" bundleMajorVer=\"0\" bundleMicroVer=\"1\" bundleMinorVer=\"0\" bundleRelease=\"0\" bundleVersion=\"1\" id=\"test-bundle\">\n" +
+					"  <meta_directives>\n" +
+					"    <timestamp>2019-09-11T21:12:17.023Z</timestamp>\n" +
+					"  </meta_directives>\n" +
+					"  <define name=\"test-ear-1.0.0\" path=\"test-ear-1.0.0.earbundle\" type=\"http://www.ibm.com/xmlns/prod/cics/bundle/EARBUNDLE\"/>\n" +
+					"</manifest>"
+				),
+				bfv(
+					EAR_BUNDLE_PART,
+					is -> assertThat(
+						is,
+						CompareMatcher.isIdenticalTo(
+							"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + 
+							"<earbundle appConfigFile=\"server.xml\" jvmserver=\"EYUCMCIJ\" symbolicname=\"test-ear-1.0.0\"/>"
+						)
+					)
+				),
+				bfv(
+					EAR_BUNDLE,
+					is -> {}
+				),
+				bfv(
+					SERVER_XML,
+					is -> assertThat(
+						is,
+						CompareMatcher.isIdenticalTo(
+							"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+							"<application id=\"test-ear\" name=\"test-ear\" type=\"ear\" location=\"test-ear-1.0.0.ear\">\n" +
+							"    <application-bnd>\n" +
+							"        <security-role name=\"Administrator\">\n" +
+							"            <user name=\"admin\" />\n" +
+							"        </security-role>\n" +
+							"    </application-bnd>\n" +
+							"</application>"
+						)
+					)
+				)
+			);
+	}
+	
+}

--- a/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildEarLibertyFull.java
+++ b/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildEarLibertyFull.java
@@ -1,0 +1,80 @@
+package com.ibm.cics.cbmp;
+/*-
+ * #%L
+ * CICS Bundle Maven Plugin
+ * %%
+ * Copyright (C) 2026 IBM Corp.
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static com.ibm.cics.cbmp.BundleValidator.assertBundleContents;
+import static com.ibm.cics.cbmp.BundleValidator.bfv;
+import static com.ibm.cics.cbmp.BundleValidator.manifestValidator;
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import org.xmlunit.matchers.CompareMatcher;
+
+public class PostBuildEarLibertyFull {
+
+	private static final String BASE_NAME = "/test-ear-1.0.0";
+	private static final String EAR_BUNDLE_PART = BASE_NAME + ".earbundle";
+	private static final String EAR_BUNDLE = BASE_NAME + ".ear";
+	private static final String SERVER_XML = "/server.xml";
+
+	public static void assertOutput(File root) throws Exception {
+		Path cicsBundle = root.toPath().resolve("target/test-bundle-0.0.1-SNAPSHOT.zip");
+		
+		assertBundleContents(
+				cicsBundle,
+				manifestValidator(
+					"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" + 
+					"<manifest xmlns=\"http://www.ibm.com/xmlns/prod/cics/bundle\" bundleMajorVer=\"0\" bundleMicroVer=\"1\" bundleMinorVer=\"0\" bundleRelease=\"0\" bundleVersion=\"1\" id=\"test-bundle\">\n" +
+					"  <meta_directives>\n" +
+					"    <timestamp>2019-09-11T21:12:17.023Z</timestamp>\n" +
+					"  </meta_directives>\n" +
+					"  <define name=\"test-ear-1.0.0\" path=\"test-ear-1.0.0.earbundle\" type=\"http://www.ibm.com/xmlns/prod/cics/bundle/EARBUNDLE\"/>\n" +
+					"</manifest>"
+				),
+				bfv(
+					EAR_BUNDLE_PART,
+					is -> assertThat(
+						is,
+						CompareMatcher.isIdenticalTo(
+							"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + 
+							"<earbundle addCICSAllAuth=\"false\" appConfigFile=\"server.xml\" jvmserver=\"EYUCMCIJ\" symbolicname=\"test-ear-1.0.0\"/>"
+						)
+					)
+				),
+				bfv(
+					EAR_BUNDLE,
+					is -> {}
+				),
+				bfv(
+					SERVER_XML,
+					is -> assertThat(
+						is,
+						CompareMatcher.isIdenticalTo(
+							"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+							"<application id=\"test-ear\" name=\"test-ear\" type=\"ear\" location=\"test-ear-1.0.0.ear\">\n" +
+							"    <application-bnd>\n" +
+							"        <security-role name=\"Administrator\">\n" +
+							"            <user name=\"admin\" />\n" +
+							"        </security-role>\n" +
+							"    </application-bnd>\n" +
+							"</application>"
+						)
+					)
+				)
+			);
+	}
+	
+}

--- a/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildTestBundleEarAuthRole.java
+++ b/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildTestBundleEarAuthRole.java
@@ -1,0 +1,56 @@
+package com.ibm.cics.cbmp;
+
+import static com.ibm.cics.cbmp.BundleValidator.assertBundleContents;
+import static com.ibm.cics.cbmp.BundleValidator.bfv;
+import static com.ibm.cics.cbmp.BundleValidator.manifestValidator;
+
+/*-
+ * #%L
+ * CICS Bundle Maven Plugin
+ * %%
+ * Copyright (C) 2026 IBM Corp.
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+
+import org.xmlunit.matchers.CompareMatcher;
+
+public class PostBuildTestBundleEarAuthRole {
+	
+	private static final String EXPECTED_MANIFEST = 
+		"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" + 
+		"<manifest xmlns=\"http://www.ibm.com/xmlns/prod/cics/bundle\" bundleMajorVer=\"0\" bundleMicroVer=\"1\" bundleMinorVer=\"0\" bundleRelease=\"0\" bundleVersion=\"1\" id=\"test-bundle-ear-auth-role\">\n" + 
+		"  <meta_directives>\n" + 
+		"    <timestamp>2019-09-10T20:24:32.893Z</timestamp>\n" + 
+		"  </meta_directives>\n" + 
+		"  <define name=\"test-bundle-ear-auth-role-0.0.1-SNAPSHOT\" path=\"test-bundle-ear-auth-role-0.0.1-SNAPSHOT.earbundle\" type=\"http://www.ibm.com/xmlns/prod/cics/bundle/EARBUNDLE\"/>\n" + 
+		"</manifest>";
+	
+	private static final String EXPECTED_BUNDLE_PART = 
+		"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" + 
+		"<earbundle addCICSAllAuth=\"false\" jvmserver=\"DFHWLP\" symbolicname=\"test-bundle-ear-auth-role-0.0.1-SNAPSHOT\"/>";
+	
+	static void assertOutput(File root) throws Exception {
+		assertBundleContents(
+			root.toPath().resolve("target/test-bundle-ear-auth-role-0.0.1-SNAPSHOT-cics-bundle.zip"),
+			manifestValidator(EXPECTED_MANIFEST),
+			bfv(
+				"/test-bundle-ear-auth-role-0.0.1-SNAPSHOT.earbundle",
+				is -> assertThat(is, CompareMatcher.isIdenticalTo(EXPECTED_BUNDLE_PART))
+			),
+			bfv(
+				"/test-bundle-ear-auth-role-0.0.1-SNAPSHOT.ear",
+				is -> {}
+			)
+		);
+	}
+}

--- a/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildTestBundleEarLibertyConfig.java
+++ b/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildTestBundleEarLibertyConfig.java
@@ -1,0 +1,68 @@
+package com.ibm.cics.cbmp;
+
+import static com.ibm.cics.cbmp.BundleValidator.assertBundleContents;
+import static com.ibm.cics.cbmp.BundleValidator.bfv;
+import static com.ibm.cics.cbmp.BundleValidator.manifestValidator;
+
+/*-
+ * #%L
+ * CICS Bundle Maven Plugin
+ * %%
+ * Copyright (C) 2026 IBM Corp.
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+
+import org.xmlunit.matchers.CompareMatcher;
+
+public class PostBuildTestBundleEarLibertyConfig {
+	
+	private static final String EXPECTED_MANIFEST = 
+		"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" + 
+		"<manifest xmlns=\"http://www.ibm.com/xmlns/prod/cics/bundle\" bundleMajorVer=\"0\" bundleMicroVer=\"1\" bundleMinorVer=\"0\" bundleRelease=\"0\" bundleVersion=\"1\" id=\"test-bundle-ear-liberty-config\">\n" + 
+		"  <meta_directives>\n" + 
+		"    <timestamp>2019-09-10T20:24:32.893Z</timestamp>\n" + 
+		"  </meta_directives>\n" + 
+		"  <define name=\"test-bundle-ear-liberty-config-0.0.1-SNAPSHOT\" path=\"test-bundle-ear-liberty-config-0.0.1-SNAPSHOT.earbundle\" type=\"http://www.ibm.com/xmlns/prod/cics/bundle/EARBUNDLE\"/>\n" + 
+		"</manifest>";
+	
+	private static final String EXPECTED_BUNDLE_PART = 
+		"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" + 
+		"<earbundle appConfigFile=\"server.xml\" jvmserver=\"DFHWLP\" symbolicname=\"test-bundle-ear-liberty-config-0.0.1-SNAPSHOT\"/>";
+	
+	private static final String EXPECTED_SERVER_XML =
+		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+		"<server>\n" +
+		"  <application>\n" +
+		"    <classloader delegation=\"parentLast\"/>\n" +
+		"  </application>\n" +
+		"</server>";
+	
+	static void assertOutput(File root) throws Exception {
+		assertBundleContents(
+			root.toPath().resolve("target/test-bundle-ear-liberty-config-0.0.1-SNAPSHOT-cics-bundle.zip"),
+			manifestValidator(EXPECTED_MANIFEST),
+			bfv(
+				"/test-bundle-ear-liberty-config-0.0.1-SNAPSHOT.earbundle",
+				is -> assertThat(is, CompareMatcher.isIdenticalTo(EXPECTED_BUNDLE_PART))
+			),
+			bfv(
+				"/test-bundle-ear-liberty-config-0.0.1-SNAPSHOT.ear",
+				is -> {}
+			),
+			bfv(
+				"/server.xml",
+				is -> assertThat(is, CompareMatcher.isIdenticalTo(EXPECTED_SERVER_XML))
+			)
+		);
+	}
+}

--- a/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildTestBundleWarAuthRole.java
+++ b/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildTestBundleWarAuthRole.java
@@ -1,0 +1,56 @@
+package com.ibm.cics.cbmp;
+
+import static com.ibm.cics.cbmp.BundleValidator.assertBundleContents;
+import static com.ibm.cics.cbmp.BundleValidator.bfv;
+import static com.ibm.cics.cbmp.BundleValidator.manifestValidator;
+
+/*-
+ * #%L
+ * CICS Bundle Maven Plugin
+ * %%
+ * Copyright (C) 2026 IBM Corp.
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+
+import org.xmlunit.matchers.CompareMatcher;
+
+public class PostBuildTestBundleWarAuthRole {
+	
+	private static final String EXPECTED_MANIFEST = 
+		"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" + 
+		"<manifest xmlns=\"http://www.ibm.com/xmlns/prod/cics/bundle\" bundleMajorVer=\"0\" bundleMicroVer=\"1\" bundleMinorVer=\"0\" bundleRelease=\"0\" bundleVersion=\"1\" id=\"test-bundle-war-auth-role\">\n" + 
+		"  <meta_directives>\n" + 
+		"    <timestamp>2019-09-10T20:24:32.893Z</timestamp>\n" + 
+		"  </meta_directives>\n" + 
+		"  <define name=\"test-bundle-war-auth-role-0.0.1-SNAPSHOT\" path=\"test-bundle-war-auth-role-0.0.1-SNAPSHOT.warbundle\" type=\"http://www.ibm.com/xmlns/prod/cics/bundle/WARBUNDLE\"/>\n" + 
+		"</manifest>";
+	
+	private static final String EXPECTED_BUNDLE_PART = 
+		"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" + 
+		"<warbundle addCICSAllAuth=\"false\" jvmserver=\"DFHWLP\" symbolicname=\"test-bundle-war-auth-role-0.0.1-SNAPSHOT\"/>";
+	
+	static void assertOutput(File root) throws Exception {
+		assertBundleContents(
+			root.toPath().resolve("target/test-bundle-war-auth-role-0.0.1-SNAPSHOT-cics-bundle.zip"),
+			manifestValidator(EXPECTED_MANIFEST),
+			bfv(
+				"/test-bundle-war-auth-role-0.0.1-SNAPSHOT.warbundle",
+				is -> assertThat(is, CompareMatcher.isIdenticalTo(EXPECTED_BUNDLE_PART))
+			),
+			bfv(
+				"/test-bundle-war-auth-role-0.0.1-SNAPSHOT.war",
+				is -> {}
+			)
+		);
+	}
+}

--- a/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildTestBundleWarLibertyConfig.java
+++ b/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildTestBundleWarLibertyConfig.java
@@ -1,0 +1,68 @@
+package com.ibm.cics.cbmp;
+
+import static com.ibm.cics.cbmp.BundleValidator.assertBundleContents;
+import static com.ibm.cics.cbmp.BundleValidator.bfv;
+import static com.ibm.cics.cbmp.BundleValidator.manifestValidator;
+
+/*-
+ * #%L
+ * CICS Bundle Maven Plugin
+ * %%
+ * Copyright (C) 2026 IBM Corp.
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+
+import org.xmlunit.matchers.CompareMatcher;
+
+public class PostBuildTestBundleWarLibertyConfig {
+	
+	private static final String EXPECTED_MANIFEST =
+		"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
+		"<manifest xmlns=\"http://www.ibm.com/xmlns/prod/cics/bundle\" bundleMajorVer=\"0\" bundleMicroVer=\"1\" bundleMinorVer=\"0\" bundleRelease=\"0\" bundleVersion=\"1\" id=\"test-bundle-war-liberty-config\">\n" +
+		"  <meta_directives>\n" +
+		"    <timestamp>2019-09-10T20:24:32.893Z</timestamp>\n" +
+		"  </meta_directives>\n" +
+		"  <define name=\"test-bundle-war-liberty-config-0.0.1-SNAPSHOT\" path=\"test-bundle-war-liberty-config-0.0.1-SNAPSHOT.warbundle\" type=\"http://www.ibm.com/xmlns/prod/cics/bundle/WARBUNDLE\"/>\n" +
+		"</manifest>";
+	
+	private static final String EXPECTED_BUNDLE_PART =
+		"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
+		"<warbundle appConfigFile=\"server.xml\" jvmserver=\"DFHWLP\" symbolicname=\"test-bundle-war-liberty-config-0.0.1-SNAPSHOT\"/>";
+	
+	private static final String EXPECTED_SERVER_XML =
+		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+		"<server>\n" +
+		"  <application>\n" +
+		"    <classloader delegation=\"parentLast\"/>\n" +
+		"  </application>\n" +
+		"</server>";
+	
+	static void assertOutput(File root) throws Exception {
+		assertBundleContents(
+			root.toPath().resolve("target/test-bundle-war-liberty-config-0.0.1-SNAPSHOT-cics-bundle.zip"),
+			manifestValidator(EXPECTED_MANIFEST),
+			bfv(
+				"/test-bundle-war-liberty-config-0.0.1-SNAPSHOT.warbundle",
+				is -> assertThat(is, CompareMatcher.isIdenticalTo(EXPECTED_BUNDLE_PART))
+			),
+			bfv(
+				"/test-bundle-war-liberty-config-0.0.1-SNAPSHOT.war",
+				is -> {}
+			),
+			bfv(
+				"/server.xml",
+				is -> assertThat(is, CompareMatcher.isIdenticalTo(EXPECTED_SERVER_XML))
+			)
+		);
+	}
+}

--- a/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildWarAuthRole.java
+++ b/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildWarAuthRole.java
@@ -1,0 +1,63 @@
+package com.ibm.cics.cbmp;
+/*-
+ * #%L
+ * CICS Bundle Maven Plugin
+ * %%
+ * Copyright (C) 2026 IBM Corp.
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static com.ibm.cics.cbmp.BundleValidator.assertBundleContents;
+import static com.ibm.cics.cbmp.BundleValidator.bfv;
+import static com.ibm.cics.cbmp.BundleValidator.manifestValidator;
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import org.xmlunit.matchers.CompareMatcher;
+
+public class PostBuildWarAuthRole {
+
+	private static final String BASE_NAME = "/test-war-1.0.0";
+	private static final String WAR_BUNDLE_PART = BASE_NAME + ".warbundle";
+	private static final String WAR_BUNDLE = BASE_NAME + ".war";
+
+	public static void assertOutput(File root) throws Exception {
+		Path cicsBundle = root.toPath().resolve("target/test-bundle-0.0.1-SNAPSHOT.zip");
+		
+		assertBundleContents(
+				cicsBundle,
+				manifestValidator(
+					"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" + 
+					"<manifest xmlns=\"http://www.ibm.com/xmlns/prod/cics/bundle\" bundleMajorVer=\"0\" bundleMicroVer=\"1\" bundleMinorVer=\"0\" bundleRelease=\"0\" bundleVersion=\"1\" id=\"test-bundle\">\n" +
+					"  <meta_directives>\n" +
+					"    <timestamp>2019-09-11T21:12:17.023Z</timestamp>\n" +
+					"  </meta_directives>\n" +
+					"  <define name=\"test-war-1.0.0\" path=\"test-war-1.0.0.warbundle\" type=\"http://www.ibm.com/xmlns/prod/cics/bundle/WARBUNDLE\"/>\n" +
+					"</manifest>"
+				),
+				bfv(
+					WAR_BUNDLE_PART,
+					is -> assertThat(
+						is,
+						CompareMatcher.isIdenticalTo(
+							"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + 
+							"<warbundle addCICSAllAuth=\"false\" jvmserver=\"EYUCMCIJ\" symbolicname=\"test-war-1.0.0\"/>"
+						)
+					)
+				),
+				bfv(
+					WAR_BUNDLE,
+					is -> {}
+				)
+			);
+	}
+	
+}

--- a/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildWarLibertyConfig.java
+++ b/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildWarLibertyConfig.java
@@ -1,0 +1,80 @@
+package com.ibm.cics.cbmp;
+/*-
+ * #%L
+ * CICS Bundle Maven Plugin
+ * %%
+ * Copyright (C) 2026 IBM Corp.
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static com.ibm.cics.cbmp.BundleValidator.assertBundleContents;
+import static com.ibm.cics.cbmp.BundleValidator.bfv;
+import static com.ibm.cics.cbmp.BundleValidator.manifestValidator;
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import org.xmlunit.matchers.CompareMatcher;
+
+public class PostBuildWarLibertyConfig {
+
+	private static final String BASE_NAME = "/test-war-1.0.0";
+	private static final String WAR_BUNDLE_PART = BASE_NAME + ".warbundle";
+	private static final String WAR_BUNDLE = BASE_NAME + ".war";
+	private static final String SERVER_XML = "/server.xml";
+
+	public static void assertOutput(File root) throws Exception {
+		Path cicsBundle = root.toPath().resolve("target/test-bundle-0.0.1-SNAPSHOT.zip");
+		
+		assertBundleContents(
+				cicsBundle,
+				manifestValidator(
+					"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" + 
+					"<manifest xmlns=\"http://www.ibm.com/xmlns/prod/cics/bundle\" bundleMajorVer=\"0\" bundleMicroVer=\"1\" bundleMinorVer=\"0\" bundleRelease=\"0\" bundleVersion=\"1\" id=\"test-bundle\">\n" +
+					"  <meta_directives>\n" +
+					"    <timestamp>2019-09-11T21:12:17.023Z</timestamp>\n" +
+					"  </meta_directives>\n" +
+					"  <define name=\"test-war-1.0.0\" path=\"test-war-1.0.0.warbundle\" type=\"http://www.ibm.com/xmlns/prod/cics/bundle/WARBUNDLE\"/>\n" +
+					"</manifest>"
+				),
+				bfv(
+					WAR_BUNDLE_PART,
+					is -> assertThat(
+						is,
+						CompareMatcher.isIdenticalTo(
+							"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + 
+							"<warbundle appConfigFile=\"server.xml\" jvmserver=\"EYUCMCIJ\" symbolicname=\"test-war-1.0.0\"/>"
+						)
+					)
+				),
+				bfv(
+					WAR_BUNDLE,
+					is -> {}
+				),
+				bfv(
+					SERVER_XML,
+					is -> assertThat(
+						is,
+						CompareMatcher.isIdenticalTo(
+							"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+							"<application id=\"test-war\" name=\"test-war\" type=\"war\" location=\"test-war-1.0.0.war\">\n" +
+							"    <application-bnd>\n" +
+							"        <security-role name=\"Administrator\">\n" +
+							"            <user name=\"admin\" />\n" +
+							"        </security-role>\n" +
+							"    </application-bnd>\n" +
+							"</application>"
+						)
+					)
+				)
+			);
+	}
+	
+}

--- a/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildWarLibertyFull.java
+++ b/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/PostBuildWarLibertyFull.java
@@ -1,0 +1,80 @@
+package com.ibm.cics.cbmp;
+/*-
+ * #%L
+ * CICS Bundle Maven Plugin
+ * %%
+ * Copyright (C) 2026 IBM Corp.
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static com.ibm.cics.cbmp.BundleValidator.assertBundleContents;
+import static com.ibm.cics.cbmp.BundleValidator.bfv;
+import static com.ibm.cics.cbmp.BundleValidator.manifestValidator;
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import org.xmlunit.matchers.CompareMatcher;
+
+public class PostBuildWarLibertyFull {
+
+	private static final String BASE_NAME = "/test-war-1.0.0";
+	private static final String WAR_BUNDLE_PART = BASE_NAME + ".warbundle";
+	private static final String WAR_BUNDLE = BASE_NAME + ".war";
+	private static final String SERVER_XML = "/server.xml";
+
+	public static void assertOutput(File root) throws Exception {
+		Path cicsBundle = root.toPath().resolve("target/test-bundle-0.0.1-SNAPSHOT.zip");
+		
+		assertBundleContents(
+				cicsBundle,
+				manifestValidator(
+					"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" + 
+					"<manifest xmlns=\"http://www.ibm.com/xmlns/prod/cics/bundle\" bundleMajorVer=\"0\" bundleMicroVer=\"1\" bundleMinorVer=\"0\" bundleRelease=\"0\" bundleVersion=\"1\" id=\"test-bundle\">\n" +
+					"  <meta_directives>\n" +
+					"    <timestamp>2019-09-11T21:12:17.023Z</timestamp>\n" +
+					"  </meta_directives>\n" +
+					"  <define name=\"test-war-1.0.0\" path=\"test-war-1.0.0.warbundle\" type=\"http://www.ibm.com/xmlns/prod/cics/bundle/WARBUNDLE\"/>\n" +
+					"</manifest>"
+				),
+				bfv(
+					WAR_BUNDLE_PART,
+					is -> assertThat(
+						is,
+						CompareMatcher.isIdenticalTo(
+							"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + 
+							"<warbundle addCICSAllAuth=\"false\" appConfigFile=\"server.xml\" jvmserver=\"EYUCMCIJ\" symbolicname=\"test-war-1.0.0\"/>"
+						)
+					)
+				),
+				bfv(
+					WAR_BUNDLE,
+					is -> {}
+				),
+				bfv(
+					SERVER_XML,
+					is -> assertThat(
+						is,
+						CompareMatcher.isIdenticalTo(
+							"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+							"<application id=\"test-war\" name=\"test-war\" type=\"war\" location=\"test-war-1.0.0.war\">\n" +
+							"    <application-bnd>\n" +
+							"        <security-role name=\"Administrator\">\n" +
+							"            <user name=\"admin\" />\n" +
+							"        </security-role>\n" +
+							"    </application-bnd>\n" +
+							"</application>"
+						)
+					)
+				)
+			);
+	}
+	
+}

--- a/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/WarbundleTest.java
+++ b/cics-bundle-maven-plugin/src/test/java/com/ibm/cics/cbmp/WarbundleTest.java
@@ -9,10 +9,16 @@ package com.ibm.cics.cbmp;
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  * #L%
  */
+
+import org.junit.Test;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
 
 public class WarbundleTest extends AbstractJavaBundlePartBindingTestCase {
 
@@ -24,6 +30,40 @@ public class WarbundleTest extends AbstractJavaBundlePartBindingTestCase {
 	@Override
 	protected String getRootElementName() {
 		return "warbundle";
+	}
+
+	@Test
+	public void addCicsAllAuthenticatedRoleFalse() throws Exception {
+		((Warbundle) binding).setAddCicsAllAuthenticatedRole(false);
+		Map<String, String> attrs = new HashMap<>();
+		attrs.put("addCICSAllAuth", "false");
+		setOtherExpectedAttributes(attrs);
+		
+		assertBundleResources();
+	}
+
+	@Test
+	public void libertyAppConfigFile() throws Exception {
+		File configFile = new File("server.xml");
+		((Warbundle) binding).setLibertyAppConfigFile(configFile);
+		Map<String, String> attrs = new HashMap<>();
+		attrs.put("appConfigFile", "server.xml");
+		setOtherExpectedAttributes(attrs);
+		
+		assertBundleResources();
+	}
+
+	@Test
+	public void bothNewProperties() throws Exception {
+		((Warbundle) binding).setAddCicsAllAuthenticatedRole(false);
+		File configFile = new File("server.xml");
+		((Warbundle) binding).setLibertyAppConfigFile(configFile);
+		Map<String, String> attrs = new HashMap<>();
+		attrs.put("addCICSAllAuth", "false");
+		attrs.put("appConfigFile", "server.xml");
+		setOtherExpectedAttributes(attrs);
+		
+		assertBundleResources();
 	}
 
 }


### PR DESCRIPTION
# PR Architecture Summary

## Overview
Added support for Liberty server configuration and authentication role control in WAR and EAR bundle parts by exposing two new properties through the Maven plugin configuration. This implementation covers both bundle part bindings (for separate bundle modules) and bundle-war/bundle-ear goals (for existing Java modules).

## Core Changes

### 1. Bundle Part Bindings (`Warbundle.java`, `Earbundle.java`)
- **Added fields:**
  - `addCicsAllAuthenticatedRole` (boolean, default: `true`)
  - `libertyAppConfigFile` (File, optional)
- **Modified:** `toBundlePartImpl()` methods now pass these parameters to `WarBundlePart` and `EarBundlePart` constructors
- **Pattern:** Direct property exposure following existing `jvmserver` property pattern

### 2. Bundle-War and Bundle-Ear Mojos (`AbstractBundleWebAppMojo.java`, `BundleWarMojo.java`, `BundleEarMojo.java`)
- **New class:** `AbstractBundleWebAppMojo` - intermediate abstract class extending `AbstractBundleJavaMojo`
- **Added Maven parameters:**
  - `@Parameter(property = "cicsbundle.addCicsAllAuthenticatedRole", defaultValue = "true")`
  - `@Parameter(property = "cicsbundle.libertyAppConfigFile")`
- **Modified:** `BundleWarMojo` and `BundleEarMojo` now extend `AbstractBundleWebAppMojo` and set properties on bundle part bindings
- **Validation:** File existence check for `libertyAppConfigFile` if specified

### 3. Integration Tests
Created 10 new integration tests:

**Reactor-based tests (6):**
- **WAR tests:** `test-reactor-war-liberty-config`, `test-reactor-war-auth-role`, `test-reactor-war-liberty-full`
- **EAR tests:** `test-reactor-ear-liberty-config`, `test-reactor-ear-auth-role`, `test-reactor-ear-liberty-full`
- **Test infrastructure:** New `setup-test-artifacts` reactor with `test-war` and `test-ear` modules

**Bundle-war/bundle-ear goal tests (4):**
- **WAR tests:** `test-bundle-war-liberty-config`, `test-bundle-war-auth-role`
- **EAR tests:** `test-bundle-ear-liberty-config`, `test-bundle-ear-auth-role`

**Validators:** 10 new `PostBuild*` classes using XMLUnit to verify:
- Bundle XML attributes (`addCICSAllAuth`, `appConfigFile`)
- Liberty server.xml file inclusion in bundles
- Correct file references in bundle part definitions

### 4. Unit Tests
- Updated `WarbundleTest` and `EarbundleTest` with test cases for new properties
- Tests verify getters/setters and `toBundlePartImpl()` parameter passing

### 5. Build Infrastructure Improvements
- **Version management:** Centralized Tycho (2.7.5) and bnd-maven-plugin (6.4.0) versions via `filterProperties`
- **Fixed:** 6 pre-existing OSGi test failures caused by outdated plugin versions
- **Result:** All 50 integration tests now pass (previously 40/46)

### 6. Documentation
- Added "Configuring bundle part properties" section to README.md (lines 161-286)
- Added "Configuring properties for bundle-war and bundle-ear goals" section (after line 320)
- Documented all properties for WAR, EAR, and OSGi bundle parts with examples
- Included single and multiple bundle part configuration examples

## Configuration Examples

**Bundle Part Configuration (separate bundle module):**
```xml
<bundlePart implementation="com.ibm.cics.cbmp.Warbundle">
  <artifact><artifactId>my-app</artifactId></artifact>
  <jvmserver>DFHWLP</jvmserver>
  <addCicsAllAuthenticatedRole>false</addCicsAllAuthenticatedRole>
  <libertyAppConfigFile>server.xml</libertyAppConfigFile>
</bundlePart>
```

**Bundle-War Goal Configuration (existing WAR module):**
```xml
<goal>bundle-war</goal>
<configuration>
  <jvmserver>DFHWLP</jvmserver>
  <addCicsAllAuthenticatedRole>false</addCicsAllAuthenticatedRole>
  <libertyAppConfigFile>src/main/liberty/server.xml</libertyAppConfigFile>
</configuration>
```