### PR TITLE
move version of maven required to build the plugin up to 3.6.3

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# Build Requirements
+
+Verify the JDK version used in .github/workflows/maven-build.yml - check that JAVA_HOME and PATH include this version before attempting to build locally.
+
+# Making updates
+Generally the tests should all pass locally. Run a clean build before starting updates to verify this.
+The build takes several minutes to run and produces a lot of output, pipe it to a file and search the output afterwards to preserve context.
+
+# Integration Tests
+
+All WireMock-based integration tests share a single port reserved by build-helper-maven-plugin. The maven-invoker-plugin version is pinned at 3.6.1 (see comment in cics-bundle-maven-plugin/pom.xml explaining why we cannot upgrade).
+
+# Local Build Failure with maven-invoker-plugin 3.6.1
+
+The `samples` module fails locally when running `mvn clean verify`:
+
+**Failure:**
+- Sample: `samples/bundle-reactor-deploy`
+- Goal: `cics-bundle:deploy` during `verify` phase
+- Error: HTTP 404 "Context Root Not Found" from `http://localhost:9080`
+- Build passes in CI but fails locally
+
+**Needs debugging** - the failure is environment-specific and the root cause is unclear. The sample attempts to deploy to `http://localhost:9080` which returns an Open Liberty 404 page.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ If you're thinking of fixing a bug or adding new features, be sure to open an is
 
 You shouldn't need to build the cics-bundle-maven project unless you plan to contribute code. In normal use you will automatically reference the built plugin from Maven Central.
 
-However if you do want to build this project, clone the repository and build `cics-bundle-maven/pom.xml`. Because this is a reactor module, all the children will also be built.
+However if you do want to build this project, you will need Maven 3.6.3 or later. Clone the repository and build `cics-bundle-maven/pom.xml`. Because this is a reactor module, all the children will also be built.
 
 To build all projects and install them into the local Maven repository, run:
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ It can deploy CICS bundles containing any bundleparts.
 
 ## Prerequisites
 
-To use the plugin to build CICS bundles, make sure that Maven is installed.
+To use the plugin to build CICS bundles, make sure that Maven 3.6.3 or later is installed.
 
 Make sure any required bundles or projects are installed into your local maven repository (.m2 cache) correctly using `mvn install` if they are not available in an online repository.
 

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
             <configuration>
               <rules>
                 <requireMavenVersion>
-                  <version>3.5.4</version>
+                  <version>3.6.3</version>
                 </requireMavenVersion>
               </rules>
             </configuration>


### PR DESCRIPTION
Some of our plugin updates require Maven 3.6.3, so updating the enforced minimum. Also adding some background information in AGENTS.md to help an AI agent work with the repo.