### PR TITLE
Update low-risk dependencies and plugins in cics-bundle-maven-plugin

### DIFF
--- a/cics-bundle-maven-plugin/pom.xml
+++ b/cics-bundle-maven-plugin/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>com.ibm.cics</groupId>
       <artifactId>cics-bundle-common</artifactId>
-      <version>2.0.3</version>
+      <version>2.0.4</version>
     </dependency>
     <dependency>
       <groupId>org.sonatype.plexus</groupId>

--- a/cics-bundle-maven-plugin/pom.xml
+++ b/cics-bundle-maven-plugin/pom.xml
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-archiver</artifactId>
-      <version>4.11.0</version>
+      <version>4.12.0</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
-      <version>3.9.6</version>
+      <version>3.9.16</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -71,14 +71,14 @@
     <dependency>
       <groupId>org.codehaus.mojo</groupId>
       <artifactId>build-helper-maven-plugin</artifactId>
-      <version>3.6.0</version>
+      <version>3.6.1</version>
     </dependency>
 
     <!-- dependencies to annotations -->
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
-      <version>3.13.0</version>
+      <version>3.15.2</version>
       <scope>provided</scope><!-- annotations are needed only to build the plugin -->
     </dependency>
     
@@ -122,43 +122,43 @@
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-model</artifactId>
         <scope>provided</scope>
-        <version>3.9.11</version>
+        <version>3.9.16</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-settings</artifactId>
         <scope>provided</scope>
-        <version>3.9.11</version>
+        <version>3.9.16</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-builder-support</artifactId>
         <scope>provided</scope>
-        <version>3.9.11</version>
+        <version>3.9.16</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-artifact</artifactId>
         <scope>provided</scope>
-        <version>3.9.11</version>
+        <version>3.9.16</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-plugin-api</artifactId>
         <scope>provided</scope>
-        <version>3.9.11</version>
+        <version>3.9.16</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-model-builder</artifactId>
         <scope>provided</scope>
-        <version>3.9.11</version>
+        <version>3.9.16</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-compat</artifactId>
         <scope>provided</scope>
-        <version>3.9.11</version>
+        <version>3.9.16</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -168,7 +168,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.12.0</version>
+        <version>3.15.2</version>
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -248,7 +248,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.6.0-M1</version>
+          <version>3.5.6</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -271,7 +271,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.6.4</version>
+        <version>3.15.2</version>
       </plugin>
     </plugins>
   </reporting>


### PR DESCRIPTION
## Summary
Update low-risk dependencies and plugins in [cics-bundle-maven-plugin/pom.xml](vscode-webview://1qpb6cst9qvhcndbdeqr0lvrq28p50qu7lq1atg74klroj8241t7/cics-bundle-maven-plugin/pom.xml) to current stable Maven 3-compatible versions.

## Changes
### Dependencies
[org.codehaus.plexus:plexus-archiver](vscode-webview://1qpb6cst9qvhcndbdeqr0lvrq28p50qu7lq1atg74klroj8241t7/cics-bundle-maven-plugin/pom.xml:40) 4.11.0 → 4.12.0
[org.apache.maven:maven-core](vscode-webview://1qpb6cst9qvhcndbdeqr0lvrq28p50qu7lq1atg74klroj8241t7/cics-bundle-maven-plugin/pom.xml:55) 3.9.6 → 3.9.16
[org.codehaus.mojo:build-helper-maven-plugin](vscode-webview://1qpb6cst9qvhcndbdeqr0lvrq28p50qu7lq1atg74klroj8241t7/cics-bundle-maven-plugin/pom.xml:73) 3.6.0 → 3.6.1
[org.apache.maven.plugin-tools:maven-plugin-annotations](vscode-webview://1qpb6cst9qvhcndbdeqr0lvrq28p50qu7lq1atg74klroj8241t7/cics-bundle-maven-plugin/pom.xml:80) 3.13.0 → 3.15.2
### Managed Maven artifacts
Updated the provided Maven artifacts in [<dependencyManagement>](vscode-webview://1qpb6cst9qvhcndbdeqr0lvrq28p50qu7lq1atg74klroj8241t7/cics-bundle-maven-plugin/pom.xml:118) from 3.9.11 to 3.9.16:

[maven-model](vscode-webview://1qpb6cst9qvhcndbdeqr0lvrq28p50qu7lq1atg74klroj8241t7/cics-bundle-maven-plugin/pom.xml:123)
[maven-settings](vscode-webview://1qpb6cst9qvhcndbdeqr0lvrq28p50qu7lq1atg74klroj8241t7/cics-bundle-maven-plugin/pom.xml:129)
[maven-builder-support](vscode-webview://1qpb6cst9qvhcndbdeqr0lvrq28p50qu7lq1atg74klroj8241t7/cics-bundle-maven-plugin/pom.xml:135)
[maven-artifact](vscode-webview://1qpb6cst9qvhcndbdeqr0lvrq28p50qu7lq1atg74klroj8241t7/cics-bundle-maven-plugin/pom.xml:141)
[maven-plugin-api](vscode-webview://1qpb6cst9qvhcndbdeqr0lvrq28p50qu7lq1atg74klroj8241t7/cics-bundle-maven-plugin/pom.xml:147)
[maven-model-builder](vscode-webview://1qpb6cst9qvhcndbdeqr0lvrq28p50qu7lq1atg74klroj8241t7/cics-bundle-maven-plugin/pom.xml:153)
[maven-compat](vscode-webview://1qpb6cst9qvhcndbdeqr0lvrq28p50qu7lq1atg74klroj8241t7/cics-bundle-maven-plugin/pom.xml:159)
### Plugins
[org.apache.maven.plugins:maven-plugin-plugin](vscode-webview://1qpb6cst9qvhcndbdeqr0lvrq28p50qu7lq1atg74klroj8241t7/cics-bundle-maven-plugin/pom.xml:170) 3.12.0 → 3.15.2
[org.apache.maven.plugins:maven-surefire-plugin](vscode-webview://1qpb6cst9qvhcndbdeqr0lvrq28p50qu7lq1atg74klroj8241t7/cics-bundle-maven-plugin/pom.xml:250) 3.6.0-M1 → 3.5.6
Reporting [org.apache.maven.plugins:maven-plugin-plugin](vscode-webview://1qpb6cst9qvhcndbdeqr0lvrq28p50qu7lq1atg74klroj8241t7/cics-bundle-maven-plugin/pom.xml:273) 3.6.4 → 3.15.2
## Why
These are low-risk version bumps that:

align the plugin module with newer stable Maven 3.9.x artifacts
replace the milestone [maven-surefire-plugin](vscode-webview://1qpb6cst9qvhcndbdeqr0lvrq28p50qu7lq1atg74klroj8241t7/cics-bundle-maven-plugin/pom.xml:250) version with a stable release
pick up fixes and compatibility improvements without changing the Java target or test architecture
## Not changed
[org.codehaus.plexus:plexus-xml](vscode-webview://1qpb6cst9qvhcndbdeqr0lvrq28p50qu7lq1atg74klroj8241t7/cics-bundle-maven-plugin/pom.xml:50) stays at 4.0.4 because the POM comment notes 4.1.1 requires Java 11+
[org.apache.maven.plugins:maven-invoker-plugin](vscode-webview://1qpb6cst9qvhcndbdeqr0lvrq28p50qu7lq1atg74klroj8241t7/cics-bundle-maven-plugin/pom.xml:201) stays at 3.6.1 because newer versions conflict with the shared WireMock port setup used by integration tests
## Validation
Validated with:
```
JAVA_HOME=~/javas/jdk11
mvn clean -pl cics-bundle-maven-plugin -am verify
```

Result:
* reactor build passed
* plugin module build passed
* integration tests passed